### PR TITLE
v2.5.2 bug fixes

### DIFF
--- a/kotor Randomizer 2/App.config
+++ b/kotor Randomizer 2/App.config
@@ -265,6 +265,9 @@
                         xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
                 </value>
             </setting>
+            <setting name="AutoGenerateSpoilers" serializeAs="String">
+                <value>False</value>
+            </setting>
         </kotor_Randomizer_2.Properties.Settings>
     </userSettings>
 </configuration>

--- a/kotor Randomizer 2/App.config
+++ b/kotor Randomizer 2/App.config
@@ -224,7 +224,7 @@
                 <value>False</value>
             </setting>
             <setting name="GoalIsMalak" serializeAs="String">
-                <value>False</value>
+                <value>True</value>
             </setting>
             <setting name="GoalIsPazaak" serializeAs="String">
                 <value>False</value>

--- a/kotor Randomizer 2/Forms/ModuleForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/ModuleForm.Designer.cs
@@ -63,36 +63,53 @@
             this.lblRule2 = new System.Windows.Forms.Label();
             this.lblRule3 = new System.Windows.Forms.Label();
             this.cbUseRandoRules = new System.Windows.Forms.CheckBox();
+            this.lblWIP = new System.Windows.Forms.Label();
+            this.lblSaveData = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.pnlSaveData = new System.Windows.Forms.Panel();
+            this.pnlTimeSavers = new System.Windows.Forms.Panel();
+            this.panel2 = new System.Windows.Forms.Panel();
+            this.lblShuffleSettings = new System.Windows.Forms.Label();
+            this.lblGeneralSettings = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.pnlGoals = new System.Windows.Forms.Panel();
+            this.pnlGlitches = new System.Windows.Forms.Panel();
+            this.pnlOther = new System.Windows.Forms.Panel();
             this.label1 = new System.Windows.Forms.Label();
+            this.pnlSaveData.SuspendLayout();
+            this.pnlTimeSavers.SuspendLayout();
+            this.pnlGoals.SuspendLayout();
+            this.pnlGlitches.SuspendLayout();
+            this.pnlOther.SuspendLayout();
             this.SuspendLayout();
             // 
             // OmittedListBox
             // 
             this.OmittedListBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
-            this.OmittedListBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.OmittedListBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.OmittedListBox.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.OmittedListBox.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.OmittedListBox.FormattingEnabled = true;
-            this.OmittedListBox.Location = new System.Drawing.Point(287, 50);
+            this.OmittedListBox.Location = new System.Drawing.Point(287, 240);
             this.OmittedListBox.Name = "OmittedListBox";
             this.OmittedListBox.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
-            this.OmittedListBox.Size = new System.Drawing.Size(248, 379);
-            this.OmittedListBox.TabIndex = 17;
+            this.OmittedListBox.Size = new System.Drawing.Size(248, 312);
+            this.OmittedListBox.TabIndex = 13;
             this.OmittedListBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.OmittedListBox_KeyPress);
             this.OmittedListBox.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.OmittedListBox_MouseDoubleClick);
             // 
             // RandomizedListBox
             // 
             this.RandomizedListBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
-            this.RandomizedListBox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.RandomizedListBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.RandomizedListBox.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.RandomizedListBox.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.RandomizedListBox.FormattingEnabled = true;
-            this.RandomizedListBox.Location = new System.Drawing.Point(20, 50);
+            this.RandomizedListBox.Location = new System.Drawing.Point(20, 240);
             this.RandomizedListBox.Name = "RandomizedListBox";
             this.RandomizedListBox.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
-            this.RandomizedListBox.Size = new System.Drawing.Size(248, 379);
-            this.RandomizedListBox.TabIndex = 16;
+            this.RandomizedListBox.Size = new System.Drawing.Size(248, 312);
+            this.RandomizedListBox.TabIndex = 12;
             this.RandomizedListBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.RandomizedListBox_KeyPress);
             this.RandomizedListBox.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.RandomizedListBox_MouseDoubleClick);
             // 
@@ -103,10 +120,11 @@
             this.PresetComboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.PresetComboBox.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.PresetComboBox.FormattingEnabled = true;
-            this.PresetComboBox.Location = new System.Drawing.Point(20, 460);
+            this.PresetComboBox.Location = new System.Drawing.Point(71, 191);
             this.PresetComboBox.Name = "PresetComboBox";
-            this.PresetComboBox.Size = new System.Drawing.Size(515, 21);
-            this.PresetComboBox.TabIndex = 18;
+            this.PresetComboBox.Size = new System.Drawing.Size(197, 21);
+            this.PresetComboBox.TabIndex = 11;
+            this.ModulesToolTip.SetToolTip(this.PresetComboBox, resources.GetString("PresetComboBox.ToolTip"));
             this.PresetComboBox.SelectedIndexChanged += new System.EventHandler(this.PresetComboBox_SelectedIndexChanged);
             // 
             // cbDeleteMilestones
@@ -115,10 +133,10 @@
             this.cbDeleteMilestones.Checked = true;
             this.cbDeleteMilestones.CheckState = System.Windows.Forms.CheckState.Checked;
             this.cbDeleteMilestones.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbDeleteMilestones.Location = new System.Drawing.Point(20, 490);
+            this.cbDeleteMilestones.Location = new System.Drawing.Point(9, 7);
             this.cbDeleteMilestones.Name = "cbDeleteMilestones";
             this.cbDeleteMilestones.Size = new System.Drawing.Size(159, 17);
-            this.cbDeleteMilestones.TabIndex = 19;
+            this.cbDeleteMilestones.TabIndex = 1;
             this.cbDeleteMilestones.Text = "Delete Milestone Save Data";
             this.ModulesToolTip.SetToolTip(this.cbDeleteMilestones, resources.GetString("cbDeleteMilestones.ToolTip"));
             this.cbDeleteMilestones.UseVisualStyleBackColor = true;
@@ -127,11 +145,10 @@
             // lblPresets
             // 
             this.lblPresets.AutoSize = true;
-            this.lblPresets.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Underline))), System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblPresets.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.lblPresets.Location = new System.Drawing.Point(20, 440);
+            this.lblPresets.Location = new System.Drawing.Point(20, 194);
             this.lblPresets.Name = "lblPresets";
-            this.lblPresets.Size = new System.Drawing.Size(53, 13);
+            this.lblPresets.Size = new System.Drawing.Size(45, 13);
             this.lblPresets.TabIndex = 20;
             this.lblPresets.Text = "Presets:";
             // 
@@ -139,10 +156,10 @@
             // 
             this.cbSaveAllMods.AutoSize = true;
             this.cbSaveAllMods.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbSaveAllMods.Location = new System.Drawing.Point(340, 490);
+            this.cbSaveAllMods.Location = new System.Drawing.Point(9, 53);
             this.cbSaveAllMods.Name = "cbSaveAllMods";
             this.cbSaveAllMods.Size = new System.Drawing.Size(157, 17);
-            this.cbSaveAllMods.TabIndex = 21;
+            this.cbSaveAllMods.TabIndex = 3;
             this.cbSaveAllMods.Text = "Include All Modules in Save";
             this.ModulesToolTip.SetToolTip(this.cbSaveAllMods, "This feature extends the minigame one to also include\r\nSTUNT cutscenes and variou" +
         "s other odd modules in the\r\nsave file.");
@@ -153,10 +170,10 @@
             // 
             this.cbSaveMiniGame.AutoSize = true;
             this.cbSaveMiniGame.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbSaveMiniGame.Location = new System.Drawing.Point(180, 490);
+            this.cbSaveMiniGame.Location = new System.Drawing.Point(9, 30);
             this.cbSaveMiniGame.Name = "cbSaveMiniGame";
             this.cbSaveMiniGame.Size = new System.Drawing.Size(153, 17);
-            this.cbSaveMiniGame.TabIndex = 22;
+            this.cbSaveMiniGame.TabIndex = 2;
             this.cbSaveMiniGame.Text = "Include Minigames in Save";
             this.ModulesToolTip.SetToolTip(this.cbSaveMiniGame, "This feature makes the game commit the minigame module\r\ndata to the save when ent" +
         "ering them, preventing possible\r\ngame crashes with randomized swoops or turrets." +
@@ -166,37 +183,34 @@
             // 
             // lblRandomized
             // 
-            this.lblRandomized.AutoSize = true;
-            this.lblRandomized.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblRandomized.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblRandomized.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.lblRandomized.Location = new System.Drawing.Point(20, 20);
+            this.lblRandomized.Location = new System.Drawing.Point(20, 219);
             this.lblRandomized.Name = "lblRandomized";
-            this.lblRandomized.Size = new System.Drawing.Size(95, 16);
+            this.lblRandomized.Size = new System.Drawing.Size(248, 14);
             this.lblRandomized.TabIndex = 23;
             this.lblRandomized.Text = "Randomized";
-            this.lblRandomized.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.lblRandomized.Click += new System.EventHandler(this.lblRandomized_Click);
+            this.lblRandomized.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // lblOmitted
             // 
-            this.lblOmitted.AutoSize = true;
-            this.lblOmitted.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblOmitted.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblOmitted.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.lblOmitted.Location = new System.Drawing.Point(460, 20);
+            this.lblOmitted.Location = new System.Drawing.Point(287, 219);
             this.lblOmitted.Name = "lblOmitted";
-            this.lblOmitted.Size = new System.Drawing.Size(61, 16);
+            this.lblOmitted.Size = new System.Drawing.Size(248, 14);
             this.lblOmitted.TabIndex = 24;
             this.lblOmitted.Text = "Omitted";
-            this.lblOmitted.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.lblOmitted.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // cbFixDream
             // 
             this.cbFixDream.AutoSize = true;
             this.cbFixDream.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbFixDream.Location = new System.Drawing.Point(20, 510);
+            this.cbFixDream.Location = new System.Drawing.Point(9, 7);
             this.cbFixDream.Name = "cbFixDream";
             this.cbFixDream.Size = new System.Drawing.Size(125, 17);
-            this.cbFixDream.TabIndex = 25;
+            this.cbFixDream.TabIndex = 4;
             this.cbFixDream.Text = "Fix Dream Sequence";
             this.ModulesToolTip.SetToolTip(this.cbFixDream, "Fixes a rare instance in which a game crash could occur\r\nwith dream sequences.");
             this.cbFixDream.UseVisualStyleBackColor = true;
@@ -206,10 +220,10 @@
             // 
             this.cbUnlockGalaxyMap.AutoSize = true;
             this.cbUnlockGalaxyMap.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbUnlockGalaxyMap.Location = new System.Drawing.Point(180, 510);
+            this.cbUnlockGalaxyMap.Location = new System.Drawing.Point(155, 30);
             this.cbUnlockGalaxyMap.Name = "cbUnlockGalaxyMap";
             this.cbUnlockGalaxyMap.Size = new System.Drawing.Size(119, 17);
-            this.cbUnlockGalaxyMap.TabIndex = 26;
+            this.cbUnlockGalaxyMap.TabIndex = 9;
             this.cbUnlockGalaxyMap.Text = "Unlock Galaxy Map";
             this.ModulesToolTip.SetToolTip(this.cbUnlockGalaxyMap, "Unlock all destinations on the Ebon Hawk galaxy map from\r\nthe start of the game.");
             this.cbUnlockGalaxyMap.UseVisualStyleBackColor = true;
@@ -219,10 +233,10 @@
             // 
             this.cbFixCoordinates.AutoSize = true;
             this.cbFixCoordinates.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbFixCoordinates.Location = new System.Drawing.Point(340, 510);
+            this.cbFixCoordinates.Location = new System.Drawing.Point(9, 53);
             this.cbFixCoordinates.Name = "cbFixCoordinates";
             this.cbFixCoordinates.Size = new System.Drawing.Size(136, 17);
-            this.cbFixCoordinates.TabIndex = 27;
+            this.cbFixCoordinates.TabIndex = 6;
             this.cbFixCoordinates.Text = "Fix Module Coordinates";
             this.ModulesToolTip.SetToolTip(this.cbFixCoordinates, resources.GetString("cbFixCoordinates.ToolTip"));
             this.cbFixCoordinates.UseVisualStyleBackColor = true;
@@ -232,10 +246,10 @@
             // 
             this.cbFixMindPrison.AutoSize = true;
             this.cbFixMindPrison.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbFixMindPrison.Location = new System.Drawing.Point(20, 530);
+            this.cbFixMindPrison.Location = new System.Drawing.Point(9, 30);
             this.cbFixMindPrison.Name = "cbFixMindPrison";
             this.cbFixMindPrison.Size = new System.Drawing.Size(97, 17);
-            this.cbFixMindPrison.TabIndex = 28;
+            this.cbFixMindPrison.TabIndex = 5;
             this.cbFixMindPrison.Text = "Fix Mind Prison";
             this.ModulesToolTip.SetToolTip(this.cbFixMindPrison, "Updates the Mystery Box so it can be used multiple times.");
             this.cbFixMindPrison.UseVisualStyleBackColor = true;
@@ -245,10 +259,10 @@
             // 
             this.cbDoorFix.AutoSize = true;
             this.cbDoorFix.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbDoorFix.Location = new System.Drawing.Point(180, 530);
+            this.cbDoorFix.Location = new System.Drawing.Point(155, 53);
             this.cbDoorFix.Name = "cbDoorFix";
             this.cbDoorFix.Size = new System.Drawing.Size(129, 17);
-            this.cbDoorFix.TabIndex = 29;
+            this.cbDoorFix.TabIndex = 10;
             this.cbDoorFix.Text = "Unlock Various Doors";
             this.ModulesToolTip.SetToolTip(this.cbDoorFix, "Unlocks the door into the Dantooine Ruins and the door\r\nout of the Unknown World\'" +
         "s Temple Summit.");
@@ -259,10 +273,10 @@
             // 
             this.cbFixLevElevators.AutoSize = true;
             this.cbFixLevElevators.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbFixLevElevators.Location = new System.Drawing.Point(340, 530);
+            this.cbFixLevElevators.Location = new System.Drawing.Point(9, 76);
             this.cbFixLevElevators.Name = "cbFixLevElevators";
             this.cbFixLevElevators.Size = new System.Drawing.Size(136, 17);
-            this.cbFixLevElevators.TabIndex = 30;
+            this.cbFixLevElevators.TabIndex = 7;
             this.cbFixLevElevators.Text = "Fix Leviathan Elevators";
             this.ModulesToolTip.SetToolTip(this.cbFixLevElevators, "The Leviathan elevator will not restrict you from going to\r\nthe Hangar early, and" +
         " the Hangar elevator is now usable.");
@@ -273,10 +287,10 @@
             // 
             this.cbVulkSpiceLZ.AutoSize = true;
             this.cbVulkSpiceLZ.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbVulkSpiceLZ.Location = new System.Drawing.Point(20, 550);
+            this.cbVulkSpiceLZ.Location = new System.Drawing.Point(155, 7);
             this.cbVulkSpiceLZ.Name = "cbVulkSpiceLZ";
             this.cbVulkSpiceLZ.Size = new System.Drawing.Size(151, 17);
-            this.cbVulkSpiceLZ.TabIndex = 31;
+            this.cbVulkSpiceLZ.TabIndex = 8;
             this.cbVulkSpiceLZ.Text = "Add Spice Lab Load Zone";
             this.ModulesToolTip.SetToolTip(this.cbVulkSpiceLZ, "A new loading zone to the unused Vulkar Spice Lab\r\nis added to the far west end o" +
         "f the Vulkar Base.");
@@ -285,12 +299,11 @@
             // 
             // cbReachability
             // 
-            this.cbReachability.AutoSize = true;
             this.cbReachability.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbReachability.Location = new System.Drawing.Point(20, 634);
+            this.cbReachability.Location = new System.Drawing.Point(20, 616);
             this.cbReachability.Name = "cbReachability";
-            this.cbReachability.Size = new System.Drawing.Size(151, 17);
-            this.cbReachability.TabIndex = 32;
+            this.cbReachability.Size = new System.Drawing.Size(151, 28);
+            this.cbReachability.TabIndex = 15;
             this.cbReachability.Text = "Verify Module Reachability";
             this.ModulesToolTip.SetToolTip(this.cbReachability, "Reachability means that all modules leading up to\r\nand including the ones contain" +
         "ing the goal(s) can\r\nbe found using either normal in-game logic or using\r\nthe gl" +
@@ -301,22 +314,28 @@
             // lblGoals
             // 
             this.lblGoals.AutoSize = true;
+            this.lblGoals.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblGoals.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.lblGoals.Location = new System.Drawing.Point(20, 658);
+            this.lblGoals.Location = new System.Drawing.Point(37, 652);
             this.lblGoals.Name = "lblGoals";
             this.lblGoals.Size = new System.Drawing.Size(132, 13);
             this.lblGoals.TabIndex = 33;
             this.lblGoals.Text = "Goal(s) of this playthrough:";
+            this.ModulesToolTip.SetToolTip(this.lblGoals, "Goals define the final win conditions. Reachability will ensure\r\nthat the modules" +
+        " related to the active goals are accessible\r\nfrom the starting module.");
             // 
             // lblGlitches
             // 
             this.lblGlitches.AutoSize = true;
+            this.lblGlitches.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblGlitches.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.lblGlitches.Location = new System.Drawing.Point(20, 681);
+            this.lblGlitches.Location = new System.Drawing.Point(202, 652);
             this.lblGlitches.Name = "lblGlitches";
             this.lblGlitches.Size = new System.Drawing.Size(138, 13);
             this.lblGlitches.TabIndex = 34;
             this.lblGlitches.Text = "Potentially required glitches:";
+            this.ModulesToolTip.SetToolTip(this.lblGlitches, "Glitches may be enabled to be in-logic, and MAY be required\r\nto complete the acti" +
+        "ve goals.\r\n\r\nDisabled glitches are NEVER required.");
             // 
             // cbGoalMalak
             // 
@@ -325,10 +344,10 @@
             this.cbGoalMalak.CheckState = System.Windows.Forms.CheckState.Checked;
             this.cbGoalMalak.Enabled = false;
             this.cbGoalMalak.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbGoalMalak.Location = new System.Drawing.Point(164, 657);
+            this.cbGoalMalak.Location = new System.Drawing.Point(3, 3);
             this.cbGoalMalak.Name = "cbGoalMalak";
             this.cbGoalMalak.Size = new System.Drawing.Size(131, 17);
-            this.cbGoalMalak.TabIndex = 35;
+            this.cbGoalMalak.TabIndex = 16;
             this.cbGoalMalak.Text = "Defeat Malak (default)";
             this.ModulesToolTip.SetToolTip(this.cbGoalMalak, "Defeat Malak on the Viewing Platform\r\nof the Star Forge.");
             this.cbGoalMalak.UseVisualStyleBackColor = true;
@@ -339,10 +358,10 @@
             this.cbGoalStarMaps.AutoSize = true;
             this.cbGoalStarMaps.Enabled = false;
             this.cbGoalStarMaps.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbGoalStarMaps.Location = new System.Drawing.Point(302, 657);
+            this.cbGoalStarMaps.Location = new System.Drawing.Point(3, 23);
             this.cbGoalStarMaps.Name = "cbGoalStarMaps";
             this.cbGoalStarMaps.Size = new System.Drawing.Size(109, 17);
-            this.cbGoalStarMaps.TabIndex = 36;
+            this.cbGoalStarMaps.TabIndex = 17;
             this.cbGoalStarMaps.Text = "Collect Star Maps";
             this.ModulesToolTip.SetToolTip(this.cbGoalStarMaps, "Collect the 5 star maps from Dantooine,\r\nKashyyyk, Korriban, Manaan, and Tatooine" +
         ".");
@@ -354,10 +373,10 @@
             this.cbGoalPazaak.AutoSize = true;
             this.cbGoalPazaak.Enabled = false;
             this.cbGoalPazaak.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbGoalPazaak.Location = new System.Drawing.Point(417, 657);
+            this.cbGoalPazaak.Location = new System.Drawing.Point(3, 43);
             this.cbGoalPazaak.Name = "cbGoalPazaak";
             this.cbGoalPazaak.Size = new System.Drawing.Size(112, 17);
-            this.cbGoalPazaak.TabIndex = 37;
+            this.cbGoalPazaak.TabIndex = 18;
             this.cbGoalPazaak.Text = "Pazaak Champion";
             this.ModulesToolTip.SetToolTip(this.cbGoalPazaak, "Defeat all pazaak players across the galaxy.");
             this.cbGoalPazaak.UseVisualStyleBackColor = true;
@@ -368,10 +387,10 @@
             this.cbGlitchDlz.AutoSize = true;
             this.cbGlitchDlz.Enabled = false;
             this.cbGlitchDlz.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbGlitchDlz.Location = new System.Drawing.Point(233, 680);
+            this.cbGlitchDlz.Location = new System.Drawing.Point(4, 23);
             this.cbGlitchDlz.Name = "cbGlitchDlz";
             this.cbGlitchDlz.Size = new System.Drawing.Size(47, 17);
-            this.cbGlitchDlz.TabIndex = 38;
+            this.cbGlitchDlz.TabIndex = 20;
             this.cbGlitchDlz.Text = "DLZ";
             this.ModulesToolTip.SetToolTip(this.cbGlitchDlz, "Displaced Loading Zone");
             this.cbGlitchDlz.UseVisualStyleBackColor = true;
@@ -382,10 +401,10 @@
             this.cbGlitchFlu.AutoSize = true;
             this.cbGlitchFlu.Enabled = false;
             this.cbGlitchFlu.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbGlitchFlu.Location = new System.Drawing.Point(286, 680);
+            this.cbGlitchFlu.Location = new System.Drawing.Point(73, 23);
             this.cbGlitchFlu.Name = "cbGlitchFlu";
             this.cbGlitchFlu.Size = new System.Drawing.Size(46, 17);
-            this.cbGlitchFlu.TabIndex = 39;
+            this.cbGlitchFlu.TabIndex = 22;
             this.cbGlitchFlu.Text = "FLU";
             this.ModulesToolTip.SetToolTip(this.cbGlitchFlu, "Fake Level Up");
             this.cbGlitchFlu.UseVisualStyleBackColor = true;
@@ -396,10 +415,10 @@
             this.cbGlitchGpw.AutoSize = true;
             this.cbGlitchGpw.Enabled = false;
             this.cbGlitchGpw.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbGlitchGpw.Location = new System.Drawing.Point(338, 680);
+            this.cbGlitchGpw.Location = new System.Drawing.Point(73, 3);
             this.cbGlitchGpw.Name = "cbGlitchGpw";
             this.cbGlitchGpw.Size = new System.Drawing.Size(52, 17);
-            this.cbGlitchGpw.TabIndex = 40;
+            this.cbGlitchGpw.TabIndex = 21;
             this.cbGlitchGpw.Text = "GPW";
             this.ModulesToolTip.SetToolTip(this.cbGlitchGpw, "Gather Party Warp / Teleport");
             this.cbGlitchGpw.UseVisualStyleBackColor = true;
@@ -408,20 +427,29 @@
             // panel1
             // 
             this.panel1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.panel1.Location = new System.Drawing.Point(20, 576);
+            this.panel1.Location = new System.Drawing.Point(20, 562);
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(515, 2);
             this.panel1.TabIndex = 41;
+            // 
+            // ModulesToolTip
+            // 
+            this.ModulesToolTip.AutoPopDelay = 10000;
+            this.ModulesToolTip.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
+            this.ModulesToolTip.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.ModulesToolTip.InitialDelay = 500;
+            this.ModulesToolTip.IsBalloon = true;
+            this.ModulesToolTip.ReshowDelay = 100;
             // 
             // cbGlitchClip
             // 
             this.cbGlitchClip.AutoSize = true;
             this.cbGlitchClip.Enabled = false;
             this.cbGlitchClip.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbGlitchClip.Location = new System.Drawing.Point(164, 680);
+            this.cbGlitchClip.Location = new System.Drawing.Point(4, 3);
             this.cbGlitchClip.Name = "cbGlitchClip";
             this.cbGlitchClip.Size = new System.Drawing.Size(63, 17);
-            this.cbGlitchClip.TabIndex = 42;
+            this.cbGlitchClip.TabIndex = 19;
             this.cbGlitchClip.Text = "Clipping";
             this.ModulesToolTip.SetToolTip(this.cbGlitchClip, "Clipping through doors, etc.");
             this.cbGlitchClip.UseVisualStyleBackColor = true;
@@ -431,10 +459,10 @@
             // 
             this.cbIgnoreOnceEdges.AutoSize = true;
             this.cbIgnoreOnceEdges.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbIgnoreOnceEdges.Location = new System.Drawing.Point(180, 634);
+            this.cbIgnoreOnceEdges.Location = new System.Drawing.Point(3, 3);
             this.cbIgnoreOnceEdges.Name = "cbIgnoreOnceEdges";
             this.cbIgnoreOnceEdges.Size = new System.Drawing.Size(164, 17);
-            this.cbIgnoreOnceEdges.TabIndex = 43;
+            this.cbIgnoreOnceEdges.TabIndex = 23;
             this.cbIgnoreOnceEdges.Text = "Ignore Single-Use Transitions";
             this.ModulesToolTip.SetToolTip(this.cbIgnoreOnceEdges, "The reachability algorithm will ignore one-time use loading\r\nzones or transitions" +
         " to fulfill the reachability condition.\r\n*Enable this option for a more stable r" +
@@ -446,7 +474,7 @@
             // 
             this.lblRule1.AutoSize = true;
             this.lblRule1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.lblRule1.Location = new System.Drawing.Point(222, 589);
+            this.lblRule1.Location = new System.Drawing.Point(222, 593);
             this.lblRule1.Name = "lblRule1";
             this.lblRule1.Size = new System.Drawing.Size(44, 13);
             this.lblRule1.TabIndex = 50;
@@ -459,7 +487,7 @@
             // 
             this.lblRule2.AutoSize = true;
             this.lblRule2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.lblRule2.Location = new System.Drawing.Point(272, 589);
+            this.lblRule2.Location = new System.Drawing.Point(272, 593);
             this.lblRule2.Name = "lblRule2";
             this.lblRule2.Size = new System.Drawing.Size(41, 13);
             this.lblRule2.TabIndex = 51;
@@ -472,7 +500,7 @@
             // 
             this.lblRule3.AutoSize = true;
             this.lblRule3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.lblRule3.Location = new System.Drawing.Point(319, 589);
+            this.lblRule3.Location = new System.Drawing.Point(319, 593);
             this.lblRule3.Name = "lblRule3";
             this.lblRule3.Size = new System.Drawing.Size(41, 13);
             this.lblRule3.TabIndex = 52;
@@ -483,66 +511,195 @@
             // 
             this.cbUseRandoRules.AutoSize = true;
             this.cbUseRandoRules.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbUseRandoRules.Location = new System.Drawing.Point(20, 588);
+            this.cbUseRandoRules.Location = new System.Drawing.Point(20, 592);
             this.cbUseRandoRules.Name = "cbUseRandoRules";
             this.cbUseRandoRules.Size = new System.Drawing.Size(196, 17);
-            this.cbUseRandoRules.TabIndex = 49;
+            this.cbUseRandoRules.TabIndex = 14;
             this.cbUseRandoRules.Text = "Use Randomization Exclusion Rules";
             this.ModulesToolTip.SetToolTip(this.cbUseRandoRules, "These rules prevent certain modules from replacing others\r\nwhen that replacement " +
         "would cause problems - inescapable\r\nor inaccessible rooms.");
             this.cbUseRandoRules.UseVisualStyleBackColor = true;
             this.cbUseRandoRules.CheckedChanged += new System.EventHandler(this.cbUseRandoRules_CheckedChanged);
             // 
+            // lblWIP
+            // 
+            this.lblWIP.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
+            this.lblWIP.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.lblWIP.Location = new System.Drawing.Point(197, 616);
+            this.lblWIP.Name = "lblWIP";
+            this.lblWIP.Size = new System.Drawing.Size(337, 28);
+            this.lblWIP.TabIndex = 53;
+            this.lblWIP.Text = "Reachability verification is a work in progress. It does not yet ensure the seed " +
+    "is beatable, but it does improve those chances.";
+            this.lblWIP.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // lblSaveData
+            // 
+            this.lblSaveData.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblSaveData.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.lblSaveData.Location = new System.Drawing.Point(20, 30);
+            this.lblSaveData.Name = "lblSaveData";
+            this.lblSaveData.Size = new System.Drawing.Size(179, 14);
+            this.lblSaveData.TabIndex = 55;
+            this.lblSaveData.Text = "Save Data";
+            this.lblSaveData.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.lblSaveData.Click += new System.EventHandler(this.lblRandomized_Click);
+            // 
+            // label3
+            // 
+            this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.label3.Location = new System.Drawing.Point(223, 30);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(312, 14);
+            this.label3.TabIndex = 56;
+            this.label3.Text = "Time Savers / Quality of Life";
+            this.label3.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // pnlSaveData
+            // 
+            this.pnlSaveData.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
+            this.pnlSaveData.Controls.Add(this.cbDeleteMilestones);
+            this.pnlSaveData.Controls.Add(this.cbSaveAllMods);
+            this.pnlSaveData.Controls.Add(this.cbSaveMiniGame);
+            this.pnlSaveData.Location = new System.Drawing.Point(20, 49);
+            this.pnlSaveData.Name = "pnlSaveData";
+            this.pnlSaveData.Size = new System.Drawing.Size(179, 79);
+            this.pnlSaveData.TabIndex = 58;
+            // 
+            // pnlTimeSavers
+            // 
+            this.pnlTimeSavers.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
+            this.pnlTimeSavers.Controls.Add(this.cbFixDream);
+            this.pnlTimeSavers.Controls.Add(this.cbUnlockGalaxyMap);
+            this.pnlTimeSavers.Controls.Add(this.cbFixCoordinates);
+            this.pnlTimeSavers.Controls.Add(this.cbFixMindPrison);
+            this.pnlTimeSavers.Controls.Add(this.cbDoorFix);
+            this.pnlTimeSavers.Controls.Add(this.cbVulkSpiceLZ);
+            this.pnlTimeSavers.Controls.Add(this.cbFixLevElevators);
+            this.pnlTimeSavers.Location = new System.Drawing.Point(223, 49);
+            this.pnlTimeSavers.Name = "pnlTimeSavers";
+            this.pnlTimeSavers.Size = new System.Drawing.Size(312, 100);
+            this.pnlTimeSavers.TabIndex = 59;
+            // 
+            // panel2
+            // 
+            this.panel2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.panel2.Location = new System.Drawing.Point(20, 159);
+            this.panel2.Name = "panel2";
+            this.panel2.Size = new System.Drawing.Size(515, 2);
+            this.panel2.TabIndex = 60;
+            // 
+            // lblShuffleSettings
+            // 
+            this.lblShuffleSettings.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblShuffleSettings.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.lblShuffleSettings.Location = new System.Drawing.Point(20, 166);
+            this.lblShuffleSettings.Name = "lblShuffleSettings";
+            this.lblShuffleSettings.Size = new System.Drawing.Size(515, 18);
+            this.lblShuffleSettings.TabIndex = 54;
+            this.lblShuffleSettings.Text = "Module Shuffle Settings";
+            this.lblShuffleSettings.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // lblGeneralSettings
+            // 
+            this.lblGeneralSettings.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblGeneralSettings.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.lblGeneralSettings.Location = new System.Drawing.Point(20, 9);
+            this.lblGeneralSettings.Name = "lblGeneralSettings";
+            this.lblGeneralSettings.Size = new System.Drawing.Size(515, 18);
+            this.lblGeneralSettings.TabIndex = 61;
+            this.lblGeneralSettings.Text = "Module General Settings";
+            this.lblGeneralSettings.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // label2
+            // 
+            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.label2.Location = new System.Drawing.Point(20, 569);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(515, 18);
+            this.label2.TabIndex = 62;
+            this.label2.Text = "Module Shuffle Logic";
+            this.label2.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // pnlGoals
+            // 
+            this.pnlGoals.AutoSize = true;
+            this.pnlGoals.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
+            this.pnlGoals.Controls.Add(this.cbGoalMalak);
+            this.pnlGoals.Controls.Add(this.cbGoalStarMaps);
+            this.pnlGoals.Controls.Add(this.cbGoalPazaak);
+            this.pnlGoals.Location = new System.Drawing.Point(37, 672);
+            this.pnlGoals.Name = "pnlGoals";
+            this.pnlGoals.Size = new System.Drawing.Size(137, 63);
+            this.pnlGoals.TabIndex = 63;
+            // 
+            // pnlGlitches
+            // 
+            this.pnlGlitches.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
+            this.pnlGlitches.Controls.Add(this.cbGlitchClip);
+            this.pnlGlitches.Controls.Add(this.cbGlitchGpw);
+            this.pnlGlitches.Controls.Add(this.cbGlitchFlu);
+            this.pnlGlitches.Controls.Add(this.cbGlitchDlz);
+            this.pnlGlitches.Location = new System.Drawing.Point(202, 672);
+            this.pnlGlitches.Name = "pnlGlitches";
+            this.pnlGlitches.Size = new System.Drawing.Size(137, 63);
+            this.pnlGlitches.TabIndex = 64;
+            // 
+            // pnlOther
+            // 
+            this.pnlOther.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
+            this.pnlOther.Controls.Add(this.cbIgnoreOnceEdges);
+            this.pnlOther.Location = new System.Drawing.Point(366, 672);
+            this.pnlOther.Name = "pnlOther";
+            this.pnlOther.Size = new System.Drawing.Size(169, 63);
+            this.pnlOther.TabIndex = 65;
+            // 
             // label1
             // 
             this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.label1.Location = new System.Drawing.Point(20, 612);
+            this.label1.Location = new System.Drawing.Point(366, 652);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(514, 13);
-            this.label1.TabIndex = 53;
-            this.label1.Text = "-- Work in progress... reachability does not yet ensure the seed is beatable, but" +
-    " it improves those chances. --";
+            this.label1.Size = new System.Drawing.Size(75, 13);
+            this.label1.TabIndex = 66;
+            this.label1.Text = "Other settings:";
             // 
             // ModuleForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
-            this.ClientSize = new System.Drawing.Size(556, 711);
+            this.ClientSize = new System.Drawing.Size(556, 752);
             this.Controls.Add(this.label1);
-            this.Controls.Add(this.lblRule3);
-            this.Controls.Add(this.lblRule2);
-            this.Controls.Add(this.lblRule1);
-            this.Controls.Add(this.cbUseRandoRules);
-            this.Controls.Add(this.cbIgnoreOnceEdges);
-            this.Controls.Add(this.cbGlitchClip);
-            this.Controls.Add(this.panel1);
-            this.Controls.Add(this.cbGlitchGpw);
-            this.Controls.Add(this.cbGlitchFlu);
-            this.Controls.Add(this.cbGlitchDlz);
-            this.Controls.Add(this.cbGoalPazaak);
-            this.Controls.Add(this.cbGoalStarMaps);
-            this.Controls.Add(this.cbGoalMalak);
-            this.Controls.Add(this.lblGlitches);
-            this.Controls.Add(this.lblGoals);
-            this.Controls.Add(this.cbReachability);
-            this.Controls.Add(this.cbVulkSpiceLZ);
-            this.Controls.Add(this.cbFixLevElevators);
-            this.Controls.Add(this.cbDoorFix);
-            this.Controls.Add(this.cbFixMindPrison);
-            this.Controls.Add(this.cbFixCoordinates);
-            this.Controls.Add(this.cbUnlockGalaxyMap);
-            this.Controls.Add(this.cbFixDream);
-            this.Controls.Add(this.lblOmitted);
-            this.Controls.Add(this.lblRandomized);
-            this.Controls.Add(this.cbSaveMiniGame);
-            this.Controls.Add(this.cbSaveAllMods);
+            this.Controls.Add(this.pnlOther);
+            this.Controls.Add(this.pnlGlitches);
+            this.Controls.Add(this.pnlGoals);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.lblGeneralSettings);
+            this.Controls.Add(this.lblShuffleSettings);
             this.Controls.Add(this.lblPresets);
-            this.Controls.Add(this.cbDeleteMilestones);
-            this.Controls.Add(this.PresetComboBox);
-            this.Controls.Add(this.OmittedListBox);
+            this.Controls.Add(this.lblWIP);
+            this.Controls.Add(this.panel2);
             this.Controls.Add(this.RandomizedListBox);
+            this.Controls.Add(this.pnlTimeSavers);
+            this.Controls.Add(this.lblRule3);
+            this.Controls.Add(this.pnlSaveData);
+            this.Controls.Add(this.OmittedListBox);
+            this.Controls.Add(this.lblRule2);
+            this.Controls.Add(this.PresetComboBox);
+            this.Controls.Add(this.lblRule1);
+            this.Controls.Add(this.lblRandomized);
+            this.Controls.Add(this.lblSaveData);
+            this.Controls.Add(this.cbUseRandoRules);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.lblOmitted);
+            this.Controls.Add(this.cbReachability);
+            this.Controls.Add(this.panel1);
+            this.Controls.Add(this.lblGoals);
+            this.Controls.Add(this.lblGlitches);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.MaximizeBox = false;
             this.Name = "ModuleForm";
@@ -551,6 +708,16 @@
             this.Text = "Modules";
             this.Activated += new System.EventHandler(this.ModuleForm_Activated);
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.ModuleForm_FormClosing);
+            this.pnlSaveData.ResumeLayout(false);
+            this.pnlSaveData.PerformLayout();
+            this.pnlTimeSavers.ResumeLayout(false);
+            this.pnlTimeSavers.PerformLayout();
+            this.pnlGoals.ResumeLayout(false);
+            this.pnlGoals.PerformLayout();
+            this.pnlGlitches.ResumeLayout(false);
+            this.pnlGlitches.PerformLayout();
+            this.pnlOther.ResumeLayout(false);
+            this.pnlOther.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -590,6 +757,18 @@
         private System.Windows.Forms.Label lblRule1;
         private System.Windows.Forms.Label lblRule2;
         private System.Windows.Forms.Label lblRule3;
+        private System.Windows.Forms.Label lblWIP;
+        private System.Windows.Forms.Label lblSaveData;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Panel pnlSaveData;
+        private System.Windows.Forms.Panel pnlTimeSavers;
+        private System.Windows.Forms.Panel panel2;
+        private System.Windows.Forms.Label lblShuffleSettings;
+        private System.Windows.Forms.Label lblGeneralSettings;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Panel pnlGoals;
+        private System.Windows.Forms.Panel pnlGlitches;
+        private System.Windows.Forms.Panel pnlOther;
         private System.Windows.Forms.Label label1;
     }
 }

--- a/kotor Randomizer 2/Forms/ModuleForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/ModuleForm.Designer.cs
@@ -264,8 +264,8 @@
             this.cbFixLevElevators.Size = new System.Drawing.Size(136, 17);
             this.cbFixLevElevators.TabIndex = 30;
             this.cbFixLevElevators.Text = "Fix Leviathan Elevators";
-            this.ModulesToolTip.SetToolTip(this.cbFixLevElevators, "The Leviathan elevator will not restrict you from going to\r\nthe Hanger early, and" +
-        " the Hanger elevator is now usable.");
+            this.ModulesToolTip.SetToolTip(this.cbFixLevElevators, "The Leviathan elevator will not restrict you from going to\r\nthe Hangar early, and" +
+        " the Hangar elevator is now usable.");
             this.cbFixLevElevators.UseVisualStyleBackColor = true;
             this.cbFixLevElevators.CheckedChanged += new System.EventHandler(this.cbFixLevElevators_CheckedChanged);
             // 

--- a/kotor Randomizer 2/Forms/ModuleForm.cs
+++ b/kotor Randomizer 2/Forms/ModuleForm.cs
@@ -93,6 +93,7 @@ namespace kotor_Randomizer_2
         // Stores omitted modules
         private void UpdateOmittedModulesSetting()
         {
+            Properties.Settings.Default.LastPresetComboIndex = PresetComboBox.SelectedIndex;
             Properties.Settings.Default.OmittedModules.Clear();
             Properties.Settings.Default.OmittedModules.AddRange(Globals.BoundModules.Where(x => x.Omitted).Select(x => x.Code).ToArray());
         }

--- a/kotor Randomizer 2/Forms/ModuleForm.cs
+++ b/kotor Randomizer 2/Forms/ModuleForm.cs
@@ -20,6 +20,15 @@ namespace kotor_Randomizer_2
         public ModuleForm()
         {
             InitializeComponent();
+            SetBorder(pnlSaveData, Color.FromArgb(0, 175, 255), 1, BorderStyle.None);
+            SetBorder(pnlTimeSavers, Color.FromArgb(0, 175, 255), 1, BorderStyle.None);
+            SetBorder(RandomizedListBox, Color.FromArgb(0, 175, 255), 1, BorderStyle.None);
+            SetBorder(OmittedListBox, Color.FromArgb(0, 175, 255), 1, BorderStyle.None);
+            SetBorder(lblWIP, Color.FromArgb(211, 216, 8), 1, BorderStyle.None);
+            SetBorder(pnlGoals, Color.FromArgb(0, 175, 255), 1, BorderStyle.None);
+            SetBorder(pnlGlitches, Color.FromArgb(0, 175, 255), 1, BorderStyle.None);
+            SetBorder(pnlOther, Color.FromArgb(0, 175, 255), 1, BorderStyle.None);
+
             var settings = Properties.Settings.Default;
 
             // Set up the controls
@@ -113,6 +122,22 @@ namespace kotor_Randomizer_2
                     Globals.BoundModules[i] = new Globals.Mod_Entry(Globals.BoundModules[i].Code, true);
                 }
             }
+        }
+
+        /// <summary>
+        /// Adds a border to the given control by adding a panel that contains it.
+        /// </summary>
+        private void SetBorder(Control ctl, Color col, int width, BorderStyle style)
+        {
+            Panel pnl = new Panel();
+            pnl.BorderStyle = style;
+            pnl.Size = new Size(ctl.Width + width * 2, ctl.Height + width * 2);
+            pnl.Location = new Point(ctl.Left - width, ctl.Top - width);
+            pnl.BackColor = col;
+            pnl.Visible = true;
+            pnl.Parent = ctl.Parent;
+            ctl.Parent = pnl;
+            ctl.Location = new Point(width, width);
         }
 
         #endregion
@@ -249,7 +274,7 @@ namespace kotor_Randomizer_2
 
         private void lblRandomized_Click(object sender, EventArgs e)
         {
-            MessageBox.Show(Convert.ToString(Properties.Settings.Default.ModuleExtrasValue));
+            MessageBox.Show(Convert.ToString(Properties.Settings.Default.ModuleExtrasValue), "Active Settings");
         }
 
         private void cbFixMindPrison_CheckedChanged(object sender, EventArgs e)

--- a/kotor Randomizer 2/Forms/ModuleForm.resx
+++ b/kotor Randomizer 2/Forms/ModuleForm.resx
@@ -120,6 +120,17 @@
   <metadata name="ModulesToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="PresetComboBox.ToolTip" xml:space="preserve">
+    <value>"Off" - Modules will not be shuffled.
+
+"Default" - Cutscenes, Endar Spire, and Ebon Hawk will
+not be shuffled.
+
+"No Major Hubs" - Default + modules with 6 or more links
+will not be shuffled.
+
+"Max Random" - All modules and cutscenes will be shuffled.</value>
+  </data>
   <data name="cbDeleteMilestones.ToolTip" xml:space="preserve">
     <value>Enabled by default in the base game. Unchecking will prevent
 the game clearing your save of presumed "unreachable" modules,
@@ -139,4 +150,7 @@ cannot replace Dreshdae)
 Similar to rule 1, this prevents binary loops that you can't
 escape from unless the other door is unlocked.</value>
   </data>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>73</value>
+  </metadata>
 </root>

--- a/kotor Randomizer 2/Forms/PathForm.cs
+++ b/kotor Randomizer 2/Forms/PathForm.cs
@@ -19,7 +19,10 @@ namespace kotor_Randomizer_2
 
             // Set up initial state from the previously saved settings.
             Kotor1Path = Properties.Settings.Default.Kotor1Path;
+            Constructed = true;
         }
+
+        private bool Constructed = false;
 
         public string Kotor1Path
         {
@@ -36,7 +39,7 @@ namespace kotor_Randomizer_2
 
         private void tbKotor1Path_TextChanged(object sender, EventArgs e)
         {
-            Properties.Settings.Default.Kotor1Path = Kotor1Path;
+            if (Constructed) Properties.Settings.Default.Kotor1Path = Kotor1Path;
         }
 
         private void bKotor1PathBrowse_Click(object sender, EventArgs e)

--- a/kotor Randomizer 2/Forms/StartForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/StartForm.Designer.cs
@@ -54,7 +54,7 @@
             this.cms1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.spoilersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.generateSpoilersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.autoCreateSpoilersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openSpoilersFolderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.closeAllOtherWindowsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.module_radio)).BeginInit();
@@ -414,7 +414,7 @@
             this.bPresets.Name = "bPresets";
             this.bPresets.Size = new System.Drawing.Size(290, 30);
             this.bPresets.TabIndex = 19;
-            this.bPresets.Text = "Presets";
+            this.bPresets.Text = "Setting Presets";
             this.bPresets.UseVisualStyleBackColor = false;
             this.bPresets.Click += new System.EventHandler(this.bPresets_Click);
             this.bPresets.MouseEnter += new System.EventHandler(this.bPresets_button_MouseEnter);
@@ -439,19 +439,21 @@
             // spoilersToolStripMenuItem
             // 
             this.spoilersToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.generateSpoilersToolStripMenuItem,
+            this.autoCreateSpoilersToolStripMenuItem,
             this.openSpoilersFolderToolStripMenuItem});
             this.spoilersToolStripMenuItem.Name = "spoilersToolStripMenuItem";
             this.spoilersToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.spoilersToolStripMenuItem.Text = "Spoiler Logs";
             // 
-            // generateSpoilersToolStripMenuItem
+            // autoCreateSpoilersToolStripMenuItem
             // 
-            this.generateSpoilersToolStripMenuItem.Enabled = false;
-            this.generateSpoilersToolStripMenuItem.Name = "generateSpoilersToolStripMenuItem";
-            this.generateSpoilersToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.generateSpoilersToolStripMenuItem.Text = "Generate Spoilers";
-            this.generateSpoilersToolStripMenuItem.Click += new System.EventHandler(this.generateSpoilersToolStripMenuItem_Click);
+            this.autoCreateSpoilersToolStripMenuItem.AutoToolTip = true;
+            this.autoCreateSpoilersToolStripMenuItem.CheckOnClick = true;
+            this.autoCreateSpoilersToolStripMenuItem.Name = "autoCreateSpoilersToolStripMenuItem";
+            this.autoCreateSpoilersToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.autoCreateSpoilersToolStripMenuItem.Text = "Auto Create Spoilers";
+            this.autoCreateSpoilersToolStripMenuItem.ToolTipText = "A spoiler log will be created automatically after the game\r\nis randomized.";
+            this.autoCreateSpoilersToolStripMenuItem.Click += new System.EventHandler(this.autoGenerateSpoilersToolStripMenuItem_Click);
             // 
             // openSpoilersFolderToolStripMenuItem
             // 
@@ -545,8 +547,8 @@
         private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem closeAllOtherWindowsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem spoilersToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem generateSpoilersToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openSpoilersFolderToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem autoCreateSpoilersToolStripMenuItem;
     }
 }
 

--- a/kotor Randomizer 2/Forms/StartForm.cs
+++ b/kotor Randomizer 2/Forms/StartForm.cs
@@ -29,7 +29,7 @@ namespace kotor_Randomizer_2
                 path_button_Click(0, new EventArgs());
             }
 
-            //Active Rando Categories (start false)
+            // Active Rando Categories (start false)
             settings.DoRandomization_Module = false;
             settings.DoRandomization_Sound = false;
             settings.DoRandomization_Model = false;
@@ -51,6 +51,7 @@ namespace kotor_Randomizer_2
             }
 
             autoCreateSpoilersToolStripMenuItem.Checked = settings.AutoGenerateSpoilers;
+            settings.PropertyChanged += Default_PropertyChanged;
 
             if (fn != "")
             {
@@ -124,7 +125,16 @@ namespace kotor_Randomizer_2
 
         private void StartForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            Properties.Settings.Default.Save();
+            // Don't allow the form to close if randomization is in progress!
+            if (FindOpenForm<RandoForm>()?.IsInProgress ?? false)
+            {
+                FocusOpenForm<RandoForm>();
+                e.Cancel = true;
+            }
+            else
+            {
+                Properties.Settings.Default.Save();
+            }
         }
 
         private void StartForm_Activated(object sender, EventArgs e)
@@ -309,6 +319,24 @@ namespace kotor_Randomizer_2
                 formsToClose[i].Close();
             }
         }
+
+        private void Default_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == "Kotor1Path")
+            {
+                if (File.Exists(Properties.Settings.Default.Kotor1Path + "\\RANDOMIZED.log"))
+                {
+                    Properties.Settings.Default.KotorIsRandomized = true;
+                    randomize_button.Text = "Unrandomize!";
+                }
+                else
+                {
+                    Properties.Settings.Default.KotorIsRandomized = false;
+                    randomize_button.Text = "Randomize!";
+                }
+            }
+        }
+
         #endregion
     }
 }

--- a/kotor Randomizer 2/Forms/StartForm.cs
+++ b/kotor Randomizer 2/Forms/StartForm.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
 using System.IO;
-using ClosedXML.Excel;
 using System.Collections.Generic;
 
 namespace kotor_Randomizer_2
@@ -51,6 +50,8 @@ namespace kotor_Randomizer_2
                 randomize_button.Text = "Randomize!";
             }
 
+            autoCreateSpoilersToolStripMenuItem.Checked = settings.AutoGenerateSpoilers;
+
             if (fn != "")
             {
                 new PresetForm(fn).Show();
@@ -64,52 +65,7 @@ namespace kotor_Randomizer_2
             KRP.WriteKRP(File.OpenWrite(path));
         }
 
-        private void CreateSpoilerLogs()
-        {
-            string spoilersPath = Path.Combine(Environment.CurrentDirectory, "Spoilers");
-            //if (Directory.Exists(spoilersPath)) { Directory.Delete(spoilersPath, true); }
-            Directory.CreateDirectory(spoilersPath);
-
-            //var timestamp = DateTime.Now.ToString("yy-MM-dd_HH-mm-ss");
-            var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH-mm-ss");
-            var filename = $"{timestamp}, Seed={Properties.Settings.Default.Seed}.xlsx";
-            var path = Path.Combine(spoilersPath, filename);
-
-            if (File.Exists(path)) { File.Delete(path); }
-
-            using (var workbook = new XLWorkbook())
-            {
-                ItemRando.GenerateSpoilerLog(workbook);
-                ModelRando.GenerateSpoilerLog(workbook);
-                ModuleRando.GenerateSpoilerLog(workbook);
-                SoundRando.GenerateSpoilerLog(workbook);
-                OtherRando.GenerateSpoilerLog(workbook);
-                TextRando.GenerateSpoilerLog(workbook);
-                TextureRando.GenerateSpoilerLog(workbook);
-                TwodaRandom.GenerateSpoilerLog(workbook);
-
-                // If any worksheets have been added, save the spoiler log.
-                if (workbook.Worksheets.Count > 0)
-                {
-                    System.Text.StringBuilder wsList = new System.Text.StringBuilder();
-                    foreach (var sheet in workbook.Worksheets)
-                    {
-                        wsList.Append($"{sheet.Name}, ");
-                    }
-                    wsList.Remove(wsList.Length - 2, 2);
-
-                    workbook.SaveAs(path);
-                    var result = MessageBox.Show($"Spoiler logs created: {wsList.ToString()}{Environment.NewLine}Open the spoilers folder?", Properties.Resources.GenerateSpoilerLogs, MessageBoxButtons.YesNo);
-                    if (result == DialogResult.Yes) { OpenSpoilersFolder(); }
-                }
-                else
-                {
-                    MessageBox.Show($"No spoiler logs created. Either the game has not been randomized, or the selected randomizations do not generate spoilers.", Properties.Resources.GenerateSpoilerLogs);
-                }
-            }
-        }
-
-        private static void OpenSpoilersFolder()
+        internal static void OpenSpoilersFolder()
         {
             var dir = Path.Combine(Environment.CurrentDirectory, "Spoilers");
             Directory.CreateDirectory(dir); // Does nothing if directory exists.
@@ -301,13 +257,11 @@ namespace kotor_Randomizer_2
                 if (Properties.Settings.Default.KotorIsRandomized)
                 {
                     randomize_button.Text = "Randomize!";
-                    generateSpoilersToolStripMenuItem.Enabled = false;
                 }
                 else
                 {
                     randomize_button.Text = "Unrandomize!";
                     LogCurrentSettings();
-                    generateSpoilersToolStripMenuItem.Enabled = true;
                 }
 
                 new RandoForm().Show();
@@ -330,9 +284,9 @@ namespace kotor_Randomizer_2
             }
         }
 
-        private void generateSpoilersToolStripMenuItem_Click(object sender, EventArgs e)
+        private void autoGenerateSpoilersToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            CreateSpoilerLogs();
+            Properties.Settings.Default.AutoGenerateSpoilers = autoCreateSpoilersToolStripMenuItem.Checked;
         }
 
         private void openSpoilersFolderToolStripMenuItem_Click(object sender, EventArgs e)

--- a/kotor Randomizer 2/Forms/StartForm.cs
+++ b/kotor Randomizer 2/Forms/StartForm.cs
@@ -13,7 +13,7 @@ namespace kotor_Randomizer_2
             InitializeComponent();
 
             Version version = typeof(StartForm).Assembly.GetName().Version;
-            this.Text = $"{this.Text} v{version.Major}.{version.Minor}";
+            this.Text = $"{this.Text} v{version.Major}.{version.Minor}.{version.Build}";
 
             Properties.Settings settings = Properties.Settings.Default;
 

--- a/kotor Randomizer 2/Forms/TextForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/TextForm.Designer.cs
@@ -30,12 +30,12 @@
         {
             this.cbDialogRando = new System.Windows.Forms.CheckBox();
             this.pDialogRando = new System.Windows.Forms.Panel();
+            this.cbMatchEntrySound = new System.Windows.Forms.CheckBox();
             this.cbReplies = new System.Windows.Forms.CheckBox();
             this.cbEntries = new System.Windows.Forms.CheckBox();
-            this.cbMatchEntrySound = new System.Windows.Forms.CheckBox();
             this.pTLK = new System.Windows.Forms.Panel();
-            this.cbTLKRando = new System.Windows.Forms.CheckBox();
             this.cbMatchStringLen = new System.Windows.Forms.CheckBox();
+            this.cbTLKRando = new System.Windows.Forms.CheckBox();
             this.pDialogRando.SuspendLayout();
             this.pTLK.SuspendLayout();
             this.SuspendLayout();
@@ -62,6 +62,17 @@
             this.pDialogRando.Size = new System.Drawing.Size(400, 40);
             this.pDialogRando.TabIndex = 4;
             // 
+            // cbMatchEntrySound
+            // 
+            this.cbMatchEntrySound.Enabled = false;
+            this.cbMatchEntrySound.Location = new System.Drawing.Point(270, 10);
+            this.cbMatchEntrySound.Name = "cbMatchEntrySound";
+            this.cbMatchEntrySound.Size = new System.Drawing.Size(130, 20);
+            this.cbMatchEntrySound.TabIndex = 2;
+            this.cbMatchEntrySound.Text = "Match Entry Sounds";
+            this.cbMatchEntrySound.UseVisualStyleBackColor = true;
+            this.cbMatchEntrySound.CheckedChanged += new System.EventHandler(this.cbMatchEntrySound_CheckedChanged);
+            // 
             // cbReplies
             // 
             this.cbReplies.Location = new System.Drawing.Point(140, 10);
@@ -82,17 +93,6 @@
             this.cbEntries.UseVisualStyleBackColor = true;
             this.cbEntries.CheckedChanged += new System.EventHandler(this.cbEntries_CheckedChanged);
             // 
-            // cbMatchEntrySound
-            // 
-            this.cbMatchEntrySound.Enabled = false;
-            this.cbMatchEntrySound.Location = new System.Drawing.Point(270, 10);
-            this.cbMatchEntrySound.Name = "cbMatchEntrySound";
-            this.cbMatchEntrySound.Size = new System.Drawing.Size(130, 20);
-            this.cbMatchEntrySound.TabIndex = 2;
-            this.cbMatchEntrySound.Text = "Match Entry Sounds";
-            this.cbMatchEntrySound.UseVisualStyleBackColor = true;
-            this.cbMatchEntrySound.CheckedChanged += new System.EventHandler(this.cbMatchEntrySound_CheckedChanged);
-            // 
             // pTLK
             // 
             this.pTLK.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
@@ -103,6 +103,16 @@
             this.pTLK.Size = new System.Drawing.Size(400, 40);
             this.pTLK.TabIndex = 5;
             // 
+            // cbMatchStringLen
+            // 
+            this.cbMatchStringLen.Location = new System.Drawing.Point(10, 10);
+            this.cbMatchStringLen.Name = "cbMatchStringLen";
+            this.cbMatchStringLen.Size = new System.Drawing.Size(170, 20);
+            this.cbMatchStringLen.TabIndex = 2;
+            this.cbMatchStringLen.Text = "Match Similar String Length";
+            this.cbMatchStringLen.UseVisualStyleBackColor = true;
+            this.cbMatchStringLen.CheckedChanged += new System.EventHandler(this.cbMatchStringLen_CheckedChanged);
+            // 
             // cbTLKRando
             // 
             this.cbTLKRando.Location = new System.Drawing.Point(20, 80);
@@ -112,16 +122,6 @@
             this.cbTLKRando.Text = "Randomize Additional Text";
             this.cbTLKRando.UseVisualStyleBackColor = true;
             this.cbTLKRando.CheckedChanged += new System.EventHandler(this.cbTLKRando_CheckedChanged);
-            // 
-            // cbMatchStringLen
-            // 
-            this.cbMatchStringLen.Location = new System.Drawing.Point(10, 10);
-            this.cbMatchStringLen.Name = "cbMatchStringLen";
-            this.cbMatchStringLen.Size = new System.Drawing.Size(170, 20);
-            this.cbMatchStringLen.TabIndex = 2;
-            this.cbMatchStringLen.Text = "Match Similair String Length";
-            this.cbMatchStringLen.UseVisualStyleBackColor = true;
-            this.cbMatchStringLen.CheckedChanged += new System.EventHandler(this.cbMatchStringLen_CheckedChanged);
             // 
             // TextF
             // 

--- a/kotor Randomizer 2/Globals.cs
+++ b/kotor Randomizer 2/Globals.cs
@@ -818,6 +818,26 @@ namespace kotor_Randomizer_2
         public static readonly Dictionary<string, List<string>> OMIT_PRESETS = new Dictionary<string, List<string>>()
         {
             //{ "<Custom>", null },
+            { "Off", new List<string>()
+                {
+                "danm13","danm14aa","danm14ab","danm14ac","danm14ad","danm14ae","danm15","danm16",
+                "ebo_m12aa","ebo_m40aa","ebo_m40ad","ebo_m41aa","ebo_m46ab",
+                "end_m01aa","end_m01ab",
+                "kas_m22aa","kas_m22ab","kas_m23aa","kas_m23ab","kas_m23ac","kas_m23ad","kas_m24aa","kas_m25aa",
+                "korr_m33aa","korr_m33ab","korr_m34aa","korr_m35aa","korr_m36aa","korr_m37aa","korr_m38aa","korr_m38ab","korr_m39aa",
+                "lev_m40aa","lev_m40ab","lev_m40ac","lev_m40ad",
+                "liv_m99aa",
+                "M12ab",
+                "manm26aa","manm26ab","manm26ac","manm26ad","manm26ae","manm26mg","manm27aa","manm28aa","manm28ab","manm28ac","manm28ad",
+                "sta_m45aa","sta_m45ab","sta_m45ac","sta_m45ad",
+                "STUNT_00","STUNT_03a","STUNT_06","STUNT_07","STUNT_12","STUNT_14","STUNT_16","STUNT_18","STUNT_19","STUNT_31b","STUNT_34","STUNT_35","STUNT_42",
+                "STUNT_44","STUNT_50a","STUNT_51a","STUNT_54a","STUNT_55a","STUNT_56a","STUNT_57",
+                "tar_m02aa","tar_m02ab","tar_m02ac","tar_m02ad","tar_m02ae","tar_m02af","tar_m03aa","tar_m03ab","tar_m03ad","tar_m03ae","tar_m03af","tar_m03mg",
+                "tar_m04aa","tar_m05aa","tar_m05ab","tar_m08aa","tar_m09aa","tar_m09ab","tar_m10aa","tar_m10ab","tar_m10ac","tar_m11aa","tar_m11ab",
+                "tat_m17aa","tat_m17ab","tat_m17ac","tat_m17ad","tat_m17ae","tat_m17af","tat_m17ag","tat_m17mg","tat_m18aa","tat_m18ab","tat_m18ac","tat_m20aa",
+                "unk_m41aa","unk_m41ab","unk_m41ac","unk_m41ad","unk_m42aa","unk_m43aa","unk_m44aa","unk_m44ab","unk_m44ac"
+                }
+            },
             { "Default", new List<string>()
                 {
                 "M12ab", "end_m01aa", "end_m01ab", "ebo_m40aa", "ebo_m12aa",
@@ -840,11 +860,71 @@ namespace kotor_Randomizer_2
                 "STUNT_56a", "STUNT_57"
                 }
             },
-            { "Max Random", new List<string>()
-                {
-                }
-            }
+            { "Max Random", new List<string>() { } }
+        };
 
+        /// <summary>
+        /// Built-in module omission presets. Same as OMIT_PRESETS, but excluding any "cutscene" modules.
+        /// </summary>
+        public static readonly Dictionary<string, List<string>> OMIT_MODULE_PRESETS = new Dictionary<string, List<string>>()
+        {
+            //{ "<Custom>", null },
+            { "Off", new List<string>()
+                {
+                "danm13","danm14aa","danm14ab","danm14ac","danm14ad","danm14ae","danm15","danm16",
+                "ebo_m12aa","ebo_m40aa","ebo_m40ad","ebo_m41aa","ebo_m46ab",
+                "end_m01aa","end_m01ab",
+                "kas_m22aa","kas_m22ab","kas_m23aa","kas_m23ab","kas_m23ac","kas_m23ad","kas_m24aa","kas_m25aa",
+                "korr_m33aa","korr_m33ab","korr_m34aa","korr_m35aa","korr_m36aa","korr_m37aa","korr_m38aa","korr_m38ab","korr_m39aa",
+                "lev_m40aa","lev_m40ab","lev_m40ac","lev_m40ad",
+                "liv_m99aa",
+                "manm26aa","manm26ab","manm26ac","manm26ad","manm26ae","manm26mg","manm27aa","manm28aa","manm28ab","manm28ac","manm28ad",
+                "sta_m45aa","sta_m45ab","sta_m45ac","sta_m45ad",
+                "tar_m02aa","tar_m02ab","tar_m02ac","tar_m02ad","tar_m02ae","tar_m02af","tar_m03aa","tar_m03ab","tar_m03ad","tar_m03ae","tar_m03af","tar_m03mg",
+                "tar_m04aa","tar_m05aa","tar_m05ab","tar_m08aa","tar_m09aa","tar_m09ab","tar_m10aa","tar_m10ab","tar_m10ac","tar_m11aa","tar_m11ab",
+                "tat_m17aa","tat_m17ab","tat_m17ac","tat_m17ad","tat_m17ae","tat_m17af","tat_m17ag","tat_m17mg","tat_m18aa","tat_m18ab","tat_m18ac","tat_m20aa",
+                "unk_m41aa","unk_m41ab","unk_m41ac","unk_m41ad","unk_m42aa","unk_m43aa","unk_m44aa","unk_m44ab","unk_m44ac"
+                }
+            },
+            { "Default", new List<string>()
+                {
+                "end_m01aa", "end_m01ab",   // Endar Spire
+                "ebo_m40aa", "ebo_m12aa", "ebo_m40ad"   // Ebon Hawk + Lev Hawks
+                }
+            },
+            { "No Major Hubs", new List<string>()
+                {
+                "liv_m99aa",    // Yavin IV
+                "tar_m10ab",    // Vulkar Spice Lab
+                "unk_m43aa",    // Rakatan Settlement
+                "unk_m44ac",    // Temple Summit
+                "manm26mg", "tar_m03mg", "tat_m17mg",   // Swoops
+                "tar_m03aa",    // Lower City (hub)
+                "tat_m17aa",    // Anchorhead (hub)
+                "korr_m36aa",   // Valley of the Dark Lords (hub)
+                "end_m01aa", "end_m01ab",   // Endar Spire (default)
+                "ebo_m40aa", "ebo_m12aa", "ebo_m40ad", "ebo_m46ab", // Ebon Hawk (default) + Mystery Box
+                }
+            },
+            { "All Modules", new List<string>() { } }
+        };
+
+        /// <summary>
+        /// Built-in cutscene omission presets. Same as OMIT_PRESETS, but only containing any "cutscene" modules.
+        /// </summary>
+        public static readonly Dictionary<string, List<string>> OMIT_CUTSCENE_PRESETS = new Dictionary<string, List<string>>()
+        {
+            //{ "<Custom>", null },
+            { "Off", new List<string>()
+                {
+                "M12ab",
+                "STUNT_00",  "STUNT_03a", "STUNT_06",  "STUNT_07",  "STUNT_12",
+                "STUNT_14",  "STUNT_16",  "STUNT_18",  "STUNT_19",  "STUNT_31b",
+                "STUNT_34",  "STUNT_35",  "STUNT_42",  "STUNT_44",  "STUNT_50a",
+                "STUNT_51a", "STUNT_54a", "STUNT_55a", "STUNT_56a", "STUNT_57",
+                }
+            },
+            { "All Cutscenes", new List<string>() { } }
         };
 
         /// <summary>

--- a/kotor Randomizer 2/Globals.cs
+++ b/kotor Randomizer 2/Globals.cs
@@ -1069,7 +1069,14 @@ namespace kotor_Randomizer_2
         /// </summary>
         public static BindingList<string> OmitItems = new BindingList<string>()
         {
-            "g_i_collarlgt001", "g_i_glowrod01", "g_i_torch01", "ptar_sitharmor", "tat17_sandperdis", "g_i_progspike02", "g_i_implant104"
+            "g_a_clothes04",    // Clothing Variant 4
+            "g_i_collarlgt001", // Collar Light
+            "g_i_glowrod01",    // Glow Rod
+            "g_i_implant104",   // Done
+            "g_i_progspike02",  // Programming Spike
+            "g_i_torch01",      // Torch
+            "ptar_sitharmor",   // Sith Armor
+            "tat17_sandperdis", // Sand People Clothing
         };
 
         /// <summary>

--- a/kotor Randomizer 2/Properties/AssemblyInfo.cs
+++ b/kotor Randomizer 2/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.5.1.0")]
-[assembly: AssemblyFileVersion("2.5.1.0")]
+[assembly: AssemblyVersion("2.5.2.0")]
+[assembly: AssemblyFileVersion("2.5.2.0")]

--- a/kotor Randomizer 2/Properties/Resources.Designer.cs
+++ b/kotor Randomizer 2/Properties/Resources.Designer.cs
@@ -71,6 +71,15 @@ namespace kotor_Randomizer_2.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Game is already randomized!.
+        /// </summary>
+        internal static string AlreadyRandomized {
+            get {
+                return ResourceManager.GetString("AlreadyRandomized", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
         internal static System.Drawing.Bitmap BoxActive {
@@ -107,6 +116,24 @@ namespace kotor_Randomizer_2.Properties {
             get {
                 object obj = ResourceManager.GetObject("BoxUnslected", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Create Spoiler Log.
+        /// </summary>
+        internal static string CreateSpoilerLog {
+            get {
+                return ResourceManager.GetString("CreateSpoilerLog", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Would you like to create a spoiler log?.
+        /// </summary>
+        internal static string CreateSpoilerLogQuestion {
+            get {
+                return ResourceManager.GetString("CreateSpoilerLogQuestion", resourceCulture);
             }
         }
         
@@ -155,15 +182,6 @@ namespace kotor_Randomizer_2.Properties {
         internal static string GeneralHelp {
             get {
                 return ResourceManager.GetString("GeneralHelp", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Generate Spoiler Logs.
-        /// </summary>
-        internal static string GenerateSpoilerLogs {
-            get {
-                return ResourceManager.GetString("GenerateSpoilerLogs", resourceCulture);
             }
         }
         
@@ -509,6 +527,24 @@ namespace kotor_Randomizer_2.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Randomized!.
+        /// </summary>
+        internal static string Randomized {
+            get {
+                return ResourceManager.GetString("Randomized", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Randomized with Spoilers!.
+        /// </summary>
+        internal static string RandomizedWithSpoilers {
+            get {
+                return ResourceManager.GetString("RandomizedWithSpoilers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Randomizing 2-D Arrays.
         /// </summary>
         internal static string Randomizing2DA {
@@ -651,6 +687,15 @@ namespace kotor_Randomizer_2.Properties {
         internal static string TwoDAHelp {
             get {
                 return ResourceManager.GetString("TwoDAHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unrandomized!.
+        /// </summary>
+        internal static string Unrandomized {
+            get {
+                return ResourceManager.GetString("Unrandomized", resourceCulture);
             }
         }
         

--- a/kotor Randomizer 2/Properties/Resources.resx
+++ b/kotor Randomizer 2/Properties/Resources.resx
@@ -337,10 +337,25 @@
   <data name="k_ren_visionland" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\k_ren_visionland.ncs;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="GenerateSpoilerLogs" xml:space="preserve">
-    <value>Generate Spoiler Logs</value>
+  <data name="CreateSpoilerLog" xml:space="preserve">
+    <value>Create Spoiler Log</value>
   </data>
   <data name="RandomizationError" xml:space="preserve">
     <value>Randomization Error</value>
+  </data>
+  <data name="AlreadyRandomized" xml:space="preserve">
+    <value>Game is already randomized!</value>
+  </data>
+  <data name="CreateSpoilerLogQuestion" xml:space="preserve">
+    <value>Would you like to create a spoiler log?</value>
+  </data>
+  <data name="Randomized" xml:space="preserve">
+    <value>Randomized!</value>
+  </data>
+  <data name="RandomizedWithSpoilers" xml:space="preserve">
+    <value>Randomized with Spoilers!</value>
+  </data>
+  <data name="Unrandomized" xml:space="preserve">
+    <value>Unrandomized!</value>
   </data>
 </root>

--- a/kotor Randomizer 2/Properties/Settings.Designer.cs
+++ b/kotor Randomizer 2/Properties/Settings.Designer.cs
@@ -833,7 +833,7 @@ namespace kotor_Randomizer_2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool GoalIsMalak {
             get {
                 return ((bool)(this["GoalIsMalak"]));

--- a/kotor Randomizer 2/Properties/Settings.Designer.cs
+++ b/kotor Randomizer 2/Properties/Settings.Designer.cs
@@ -987,5 +987,17 @@ namespace kotor_Randomizer_2.Properties {
                 this["OmittedModules"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool AutoGenerateSpoilers {
+            get {
+                return ((bool)(this["AutoGenerateSpoilers"]));
+            }
+            set {
+                this["AutoGenerateSpoilers"] = value;
+            }
+        }
     }
 }

--- a/kotor Randomizer 2/Properties/Settings.settings
+++ b/kotor Randomizer 2/Properties/Settings.settings
@@ -247,5 +247,8 @@
       <Value Profile="(Default)">&lt;?xml version="1.0" encoding="utf-16"?&gt;
 &lt;ArrayOfString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" /&gt;</Value>
     </Setting>
+    <Setting Name="AutoGenerateSpoilers" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/kotor Randomizer 2/Properties/Settings.settings
+++ b/kotor Randomizer 2/Properties/Settings.settings
@@ -208,7 +208,7 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="GoalIsMalak" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
+      <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="GoalIsPazaak" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>

--- a/kotor Randomizer 2/Randomization/ItemRando.cs
+++ b/kotor Randomizer 2/Randomization/ItemRando.cs
@@ -47,7 +47,7 @@ namespace kotor_Randomizer_2
             HandleCategory(k, StimsRegs, Properties.Settings.Default.RandomizeStims);
             HandleCategory(k, UpgradeRegs, Properties.Settings.Default.RandomizeUpgrade);
 
-            //handle Various
+            // Handle Various
             switch (Properties.Settings.Default.RandomizeVarious)
             {
                 default:
@@ -62,7 +62,13 @@ namespace kotor_Randomizer_2
                     break;
             }
 
-            //Max Rando
+            // Omitted Items
+            foreach (var item in Globals.OmitItems)
+            {
+                LookupTable.Add(new Tuple<string, string>(item, item));
+            }
+
+            // Max Rando
             List<string> Max_Rando_Iterator = new List<string>(Max_Rando);
             Randomize.FisherYatesShuffle(Max_Rando);
             int j = 0;
@@ -73,7 +79,7 @@ namespace kotor_Randomizer_2
                 j++;
             }
 
-            //Type Rando
+            // Type Rando
             foreach (List<string> li in Type_Lists)
             {
                 List<string> type_copy = new List<string>(li);
@@ -209,7 +215,7 @@ namespace kotor_Randomizer_2
             LookupTable.Clear();
         }
 
-        public static void GenerateSpoilerLog(XLWorkbook workbook)
+        public static void CreateSpoilerLog(XLWorkbook workbook)
         {
             if (LookupTable.Count == 0) { return; }
             var ws = workbook.Worksheets.Add("Item");
@@ -349,6 +355,7 @@ namespace kotor_Randomizer_2
             {
                 string origItemName = "";
                 string randItemName = "";
+                var omitted = Globals.OmitItems.Any(x => x == tpl.Item1);
                 var changed = tpl.Item1 != tpl.Item2;   // Has the shuffle changed this item?
 
                 var origItemVre = items.FirstOrDefault(x => x.ResRef == tpl.Item1);
@@ -374,7 +381,7 @@ namespace kotor_Randomizer_2
                     randItemName = origItemName;
                 }
 
-                ws.Cell(i, 1).Value = changed.ToString();
+                ws.Cell(i, 1).Value = omitted ? "OMITTED" : changed.ToString();
                 ws.Cell(i, 2).Style.Border.LeftBorder = XLBorderStyleValues.Thin;
                 ws.Cell(i, 2).Value = tpl.Item1;
                 ws.Cell(i, 3).Value = origItemName;
@@ -382,8 +389,17 @@ namespace kotor_Randomizer_2
                 ws.Cell(i, 4).Value = tpl.Item2;
                 ws.Cell(i, 5).Value = randItemName;
                 ws.Cell(i, 6).Style.Border.LeftBorder = XLBorderStyleValues.Thin;
-                if (changed) ws.Cell(i, 1).Style.Font.FontColor = XLColor.Green;
-                else         ws.Cell(i, 1).Style.Font.FontColor = XLColor.Red;
+                if (omitted)
+                {
+                    // Center "OMITTED" text.
+                    ws.Cell(i, 1).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+                }
+                else
+                {
+                    // Set color of "Has Changed" column. Booleans are automatically centered.
+                    if (changed) ws.Cell(i, 1).Style.Font.FontColor = XLColor.Green;
+                    else         ws.Cell(i, 1).Style.Font.FontColor = XLColor.Red;
+                }
                 i++;
             }
 

--- a/kotor Randomizer 2/Randomization/ItemRando.cs
+++ b/kotor Randomizer 2/Randomization/ItemRando.cs
@@ -269,40 +269,77 @@ namespace kotor_Randomizer_2
             i++;    // Skip a row.
 
             // Omitted Items
-            ws.Cell(i, 1).Value = "Omitted Items";
-            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
-            ws.Cell(i, 1).Style.Font.Bold = true;
+            int iMax = i;
+            i = 3;  // Restart at the top of the settings list.
+
+            ws.Cell(i, 4).Value = "Omitted Items";
+            ws.Cell(i, 4).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+            ws.Cell(i, 4).Style.Font.Bold = true;
+            ws.Range(i, 4, i, 5).Merge();
             i++;
 
-            foreach (var item in Globals.OmitItems)
-            {
-                ws.Cell(i, 1).Value = item;
-                i++;
-            }
-            i += 2;     // Skip a couple row.
-
-            // Randomized Items
-            ws.Cell(i, 1).Value = "Has Changed";
-            ws.Cell(i-1, 2).Value = "Original";
-            ws.Cell(i, 2).Value = "ID";
-            ws.Cell(i, 3).Value = "Label";
-            ws.Cell(i-1, 4).Value = "Randomized";
             ws.Cell(i, 4).Value = "ID";
             ws.Cell(i, 5).Value = "Label";
-            ws.Cell(i-1, 2).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
-            ws.Cell(i-1, 4).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
-            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
-            ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
-            ws.Cell(i, 3).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             ws.Cell(i, 4).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
             ws.Cell(i, 5).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
-            ws.Cell(i, 1).Style.Font.Bold = true;
-            ws.Cell(i-1, 2).Style.Font.Bold = true;
-            ws.Cell(i, 2).Style.Font.Italic = true;
-            ws.Cell(i, 3).Style.Font.Italic = true;
-            ws.Cell(i-1, 4).Style.Font.Bold = true;
             ws.Cell(i, 4).Style.Font.Italic = true;
             ws.Cell(i, 5).Style.Font.Italic = true;
+            i++;
+
+            var sortedList = Globals.OmitItems.ToList();
+            sortedList.Sort();
+
+            foreach (var item in sortedList)
+            {
+                ws.Cell(i, 4).Value = item;
+                var origItemName = "";
+
+                var origItemVre = items.FirstOrDefault(x => x.ResRef == item);
+                if (origItemVre != null)
+                {
+                    GFF origItem = new GFF(origItemVre.EntryData);
+                    if (origItem.Top_Level.Fields.FirstOrDefault(x => x.Label == "LocalizedName") is GFF.CExoLocString field)
+                        origItemName = t.String_Data_Table[field.StringRef].StringText;
+                }
+
+                ws.Cell(i, 5).Value = origItemName;
+                i++;
+            }
+
+            // Handle variable length of omitted items list.
+            if (iMax > i) i = iMax; // Return to the bottom of the settings list.
+            else          i++;      // Skip a row.
+
+            i++;    // Skip an additional row.
+
+            // Randomized Items
+            ws.Cell(i,   1).Value = "Has Changed";
+            ws.Cell(i-1, 2).Value = "Original";
+            ws.Cell(i,   2).Value = "ID";
+            ws.Cell(i,   3).Value = "Label";
+            ws.Cell(i-1, 4).Value = "Randomized";
+            ws.Cell(i,   4).Value = "ID";
+            ws.Cell(i,   5).Value = "Label";
+            ws.Cell(i-1, 2).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+            ws.Cell(i-1, 4).Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+            ws.Cell(i,   1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i,   2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i,   3).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i,   4).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i,   5).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i-1, 2).Style.Border.LeftBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i,   2).Style.Border.LeftBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i-1, 4).Style.Border.LeftBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i,   4).Style.Border.LeftBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i-1, 6).Style.Border.LeftBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i,   6).Style.Border.LeftBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i,   1).Style.Font.Bold = true;
+            ws.Cell(i-1, 2).Style.Font.Bold = true;
+            ws.Cell(i,   2).Style.Font.Italic = true;
+            ws.Cell(i,   3).Style.Font.Italic = true;
+            ws.Cell(i-1, 4).Style.Font.Bold = true;
+            ws.Cell(i,   4).Style.Font.Italic = true;
+            ws.Cell(i,   5).Style.Font.Italic = true;
             ws.Range(i-1, 2, i-1, 3).Merge();
             ws.Range(i-1, 4, i-1, 5).Merge();
             i++;
@@ -312,6 +349,7 @@ namespace kotor_Randomizer_2
             {
                 string origItemName = "";
                 string randItemName = "";
+                var changed = tpl.Item1 != tpl.Item2;   // Has the shuffle changed this item?
 
                 var origItemVre = items.FirstOrDefault(x => x.ResRef == tpl.Item1);
                 if (origItemVre != null)
@@ -321,22 +359,31 @@ namespace kotor_Randomizer_2
                         origItemName = t.String_Data_Table[field.StringRef].StringText;
                 }
 
-                var randItemVre = items.FirstOrDefault(x => x.ResRef == tpl.Item2);
-                if (randItemVre != null)
+                if (changed)
                 {
-                    GFF randItem = new GFF(randItemVre.EntryData);
-                    if (randItem.Top_Level.Fields.FirstOrDefault(x => x.Label == "LocalizedName") is GFF.CExoLocString field)
-                        randItemName = t.String_Data_Table[field.StringRef].StringText;
+                    var randItemVre = items.FirstOrDefault(x => x.ResRef == tpl.Item2);
+                    if (randItemVre != null)
+                    {
+                        GFF randItem = new GFF(randItemVre.EntryData);
+                        if (randItem.Top_Level.Fields.FirstOrDefault(x => x.Label == "LocalizedName") is GFF.CExoLocString field)
+                            randItemName = t.String_Data_Table[field.StringRef].StringText;
+                    }
+                }
+                else
+                {
+                    randItemName = origItemName;
                 }
 
-                var hasChanged = tpl.Item1 != tpl.Item2;
-                ws.Cell(i, 1).Value = hasChanged.ToString();
+                ws.Cell(i, 1).Value = changed.ToString();
+                ws.Cell(i, 2).Style.Border.LeftBorder = XLBorderStyleValues.Thin;
                 ws.Cell(i, 2).Value = tpl.Item1;
                 ws.Cell(i, 3).Value = origItemName;
+                ws.Cell(i, 4).Style.Border.LeftBorder = XLBorderStyleValues.Thin;
                 ws.Cell(i, 4).Value = tpl.Item2;
                 ws.Cell(i, 5).Value = randItemName;
-                if (hasChanged) ws.Cell(i, 1).Style.Font.FontColor = XLColor.Green;
-                else            ws.Cell(i, 1).Style.Font.FontColor = XLColor.Red;
+                ws.Cell(i, 6).Style.Border.LeftBorder = XLBorderStyleValues.Thin;
+                if (changed) ws.Cell(i, 1).Style.Font.FontColor = XLColor.Green;
+                else         ws.Cell(i, 1).Style.Font.FontColor = XLColor.Red;
                 i++;
             }
 

--- a/kotor Randomizer 2/Randomization/ModelRando.cs
+++ b/kotor Randomizer 2/Randomization/ModelRando.cs
@@ -235,7 +235,7 @@ namespace kotor_Randomizer_2
             LookupTable.Clear();
         }
 
-        public static void GenerateSpoilerLog(XLWorkbook workbook)
+        public static void CreateSpoilerLog(XLWorkbook workbook)
         {
             if (LookupTable.Count == 0) { return; }
             var ws = workbook.Worksheets.Add("Model");

--- a/kotor Randomizer 2/Randomization/ModuleRando.cs
+++ b/kotor Randomizer 2/Randomization/ModuleRando.cs
@@ -16,7 +16,7 @@ namespace kotor_Randomizer_2
         private const string AREA_TEMPLE_ROOF = "unk_m44ac";
         private const string AREA_LEVI_PRISON = "lev_m40aa";
         private const string AREA_LEVI_COMMAND = "lev_m40ab";
-        private const string AREA_LEVI_HANGER = "lev_m40ac";
+        private const string AREA_LEVI_HANGAR = "lev_m40ac";
         private const string AREA_VULKAR_BASE = "tar_m10aa";
         private const string LABEL_MIND_PRISON = "g_brakatan003";
         private const string LABEL_MYSTERY_BOX = "pebn_mystery";
@@ -58,18 +58,76 @@ namespace kotor_Randomizer_2
             bool reachable = false;
             int iterations = 0;
 
-            if (Properties.Settings.Default.UseRandoRules ||
-                Properties.Settings.Default.VerifyReachability)
+            // Only shuffle if there is more than 1 module in the shuffle.
+            if (IncludedModules.Count > 1)
             {
-                System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
-                sw.Start();
-
-                while (!reachable && iterations < MAX_ITERATIONS)
+                if (Properties.Settings.Default.UseRandoRules ||
+                    Properties.Settings.Default.VerifyReachability)
                 {
-                    iterations++;
+                    System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
+                    sw.Start();
 
-                    Console.WriteLine($"Iteration {iterations}:");
+                    while (!reachable && iterations < MAX_ITERATIONS)
+                    {
+                        iterations++;
 
+                        Console.WriteLine($"Iteration {iterations}:");
+
+                        // Shuffle the list of included modules.
+                        List<string> ShuffledModules = IncludedModules.ToList();
+                        Randomize.FisherYatesShuffle(ShuffledModules);
+                        LookupTable.Clear();
+
+                        for (int i = 0; i < IncludedModules.Count; i++)
+                        {
+                            LookupTable.Add(IncludedModules[i], ShuffledModules[i]);
+                        }
+
+                        foreach (string name in ExcludedModules)
+                        {
+                            LookupTable.Add(name, name);
+                        }
+
+                        Digraph.SetRandomizationLookup(LookupTable);
+
+                        if (Properties.Settings.Default.UseRandoRules)
+                        {
+                            // Skip to the next iteration if the rules are violated.
+                            if (AreRulesViolated()) continue;
+                        }
+
+                        if (Properties.Settings.Default.VerifyReachability)
+                        {
+                            Digraph.CheckReachability();
+                            reachable = Digraph.IsGoalReachable();
+                        }
+                        else
+                        {
+                            reachable = true;
+                        }
+                    }
+
+                    if (Properties.Settings.Default.VerifyReachability)
+                    {
+                        if (reachable)
+                        {
+                            var message = $"Reachable solution found after {iterations} shuffles. Time elapsed: {sw.Elapsed}";
+                            Console.WriteLine(message);
+                        }
+                        else
+                        {
+                            // Throw an exception if not reachable.
+                            var message = $"No reachable solution found over {iterations} shuffles. Time elapsed: {sw.Elapsed}";
+                            Console.WriteLine(message);
+                            throw new TimeoutException(message);
+                        }
+                    }
+
+                    //digraph.WriteReachableToConsole();
+                    Console.WriteLine();
+                }
+                else
+                {
                     // Shuffle the list of included modules.
                     List<string> ShuffledModules = IncludedModules.ToList();
                     Randomize.FisherYatesShuffle(ShuffledModules);
@@ -84,55 +142,16 @@ namespace kotor_Randomizer_2
                     {
                         LookupTable.Add(name, name);
                     }
-
-                    Digraph.SetRandomizationLookup(LookupTable);
-
-                    if (Properties.Settings.Default.UseRandoRules)
-                    {
-                        // Skip to the next iteration if the rules are violated.
-                        if (AreRulesViolated()) continue;
-                    }
-
-                    if (Properties.Settings.Default.VerifyReachability)
-                    {
-                        Digraph.CheckReachability();
-                        reachable = Digraph.IsGoalReachable();
-                    }
-                    else
-                    {
-                        reachable = true;
-                    }
                 }
-
-                if (Properties.Settings.Default.VerifyReachability)
-                {
-                    if (reachable)
-                    {
-                        var message = $"Reachable solution found after {iterations} shuffles. Time elapsed: {sw.Elapsed}";
-                        Console.WriteLine(message);
-                    }
-                    else
-                    {
-                        // Throw an exception if not reachable.
-                        var message = $"No reachable solution found over {iterations} shuffles. Time elapsed: {sw.Elapsed}";
-                        Console.WriteLine(message);
-                        throw new TimeoutException(message);
-                    }
-                }
-
-                //digraph.WriteReachableToConsole();
-                Console.WriteLine();
             }
             else
             {
-                // Shuffle the list of included modules.
-                List<string> ShuffledModules = IncludedModules.ToList();
-                Randomize.FisherYatesShuffle(ShuffledModules);
+                // Create lookup table for later features.
                 LookupTable.Clear();
 
                 for (int i = 0; i < IncludedModules.Count; i++)
                 {
-                    LookupTable.Add(IncludedModules[i], ShuffledModules[i]);
+                    LookupTable.Add(IncludedModules[i], IncludedModules[i]);
                 }
 
                 foreach (string name in ExcludedModules)
@@ -229,7 +248,7 @@ namespace kotor_Randomizer_2
 
                     GFF g = new GFF(rf.File_Data);
 
-                    //Update coordinate data.
+                    // Update coordinate data.
                     (g.Top_Level.Fields.Where(x => x.Label == Properties.Resources.ModuleEntryX).FirstOrDefault() as GFF.FLOAT).Value = Globals.FIXED_COORDINATES[kvp.Key].Item1;
                     (g.Top_Level.Fields.Where(x => x.Label == Properties.Resources.ModuleEntryY).FirstOrDefault() as GFF.FLOAT).Value = Globals.FIXED_COORDINATES[kvp.Key].Item2;
                     (g.Top_Level.Fields.Where(x => x.Label == Properties.Resources.ModuleEntryZ).FirstOrDefault() as GFF.FLOAT).Value = Globals.FIXED_COORDINATES[kvp.Key].Item3;
@@ -243,7 +262,7 @@ namespace kotor_Randomizer_2
             // Fixed Rakata riddle Man in Mind Prison.
             if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixMindPrison))
             {
-                //Allowing Mystery Box to be accessed multiple times
+                // Allowing Mystery Box to be accessed multiple times...
                 // Find the files associated with AREA_EBON_HAWK.
                 var hawk_files = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_EBON_HAWK]));
                 foreach (FileInfo fi in hawk_files)
@@ -270,7 +289,7 @@ namespace kotor_Randomizer_2
                     }
                 }
 
-                //Allowing Riddles to be done more than once
+                // Allowing Riddles to be done more than once...
                 // Find the files associated with AREA_MYSTERY_BOX.
                 var files = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_MYSTERY_BOX]));
                 foreach (FileInfo fi in files)
@@ -298,20 +317,20 @@ namespace kotor_Randomizer_2
                 }
             }
 
-            //Unlock doors to dantooine ruins and on Lehon Temple Roof
+            // Unlock doors to dantooine ruins and on Lehon Temple Roof
             if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockVarDoors))
             {
-                //Dantooine Ruins
+                // Dantooine Ruins
                 var dan_files = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_DANTOOINE_COURTYARD]));
                 foreach (FileInfo fi in dan_files)
                 {
                     // Skip any files that don't end in "s.rim".
                     if (fi.Name[fi.Name.Length - 5] != 's') { continue; }
 
-                    RIM r_dan = new RIM(fi.FullName); //Open what replaced danm14aa_s.rim
-                    GFF g_dan = new GFF(r_dan.File_Table.Where(x => x.Label == LABEL_DANTOOINE_DOOR).FirstOrDefault().File_Data); //Grab the door out of there
+                    RIM r_dan = new RIM(fi.FullName); // Open what replaced danm14aa_s.rim
+                    GFF g_dan = new GFF(r_dan.File_Table.Where(x => x.Label == LABEL_DANTOOINE_DOOR).FirstOrDefault().File_Data); // Grab the door out of there
 
-                    //Set the "Locked" field to 0 (false)
+                    // Set the "Locked" field to 0 (false)
                     (g_dan.Top_Level.Fields.Where(x => x.Label == "Locked").FirstOrDefault() as GFF.BYTE).Value = 0;
 
                     r_dan.File_Table.Where(x => x.Label == LABEL_DANTOOINE_DOOR).FirstOrDefault().File_Data = g_dan.ToRawData();
@@ -319,17 +338,17 @@ namespace kotor_Randomizer_2
                     r_dan.WriteToFile(fi.FullName);
                 }
 
-                //Lehon Temple Roof
+                // Lehon Temple Roof
                 var unk_files = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_TEMPLE_ROOF]));
                 foreach (FileInfo fi in unk_files)
                 {
                     // Skip any files that don't end in "s.rim".
                     if (fi.Name[fi.Name.Length - 5] != 's') { continue; }
 
-                    RIM r_unk = new RIM(fi.FullName); //Open what replaced unk_m44aa_s.rim
-                    GFF g_unk = new GFF(r_unk.File_Table.Where(x => x.Label == LABEL_LEHON_DOOR).FirstOrDefault().File_Data); //Grab the door out of there
+                    RIM r_unk = new RIM(fi.FullName); // Open what replaced unk_m44aa_s.rim
+                    GFF g_unk = new GFF(r_unk.File_Table.Where(x => x.Label == LABEL_LEHON_DOOR).FirstOrDefault().File_Data); // Grab the door out of there
 
-                    //Set the "Locked" field to 0 (false)
+                    // Set the "Locked" field to 0 (false)
                     (g_unk.Top_Level.Fields.Where(x => x.Label == "Locked").FirstOrDefault() as GFF.BYTE).Value = 0;
 
                     r_unk.File_Table.Where(x => x.Label == LABEL_LEHON_DOOR).FirstOrDefault().File_Data = g_unk.ToRawData();
@@ -338,14 +357,14 @@ namespace kotor_Randomizer_2
                 }
             }
 
-            //Leviathan Elevators
+            // Leviathan Elevators
             if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators))
             {
                 var lev_files_a = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_LEVI_PRISON]));
                 var lev_files_b = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_LEVI_COMMAND]));
-                var lev_files_c = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_LEVI_HANGER]));
+                var lev_files_c = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_LEVI_HANGAR]));
 
-                //Prison Block Fix
+                // Prison Block Fix
                 foreach (FileInfo fi in lev_files_a)
                 {
                     // Skip any files that don't end in "s.rim".
@@ -354,9 +373,10 @@ namespace kotor_Randomizer_2
                     RIM r_lev = new RIM(fi.FullName);
                     GFF g_lev = new GFF(r_lev.File_Table.Where(x => x.Label == LABEL_LEVI_ELEVATOR_A).FirstOrDefault().File_Data);
 
-                    //Change Entry connecting for bridge option Index to 3, which will transition to the command deck
+                    // Change Entry connecting for bridge option Index to 3, which will transition to the command deck
                     (((g_lev.Top_Level.Fields.Where(x => x.Label == "ReplyList").FirstOrDefault() as GFF.LIST).Structs.Where(x => x.Struct_Type == 3).FirstOrDefault().Fields.Where(x => x.Label == "EntriesList").FirstOrDefault() as GFF.LIST).Structs.Where(x => x.Struct_Type == 0).FirstOrDefault().Fields.Where(x => x.Label == "Index").FirstOrDefault() as GFF.DWORD).Value = 3;
-                    //Sets the active reference for the hanger option to nothing, meaning there is no requirement to transition to the hanger
+
+                    // Sets the active reference for the hangar option to nothing, meaning there is no requirement to transition to the hangar
                     (((g_lev.Top_Level.Fields.Where(x => x.Label == "ReplyList").FirstOrDefault() as GFF.LIST).Structs.Where(x => x.Struct_Type == 1).FirstOrDefault().Fields.Where(x => x.Label == "EntriesList").FirstOrDefault() as GFF.LIST).Structs.Where(x => x.Struct_Type == 0).FirstOrDefault().Fields.Where(x => x.Label == "Active").FirstOrDefault() as GFF.ResRef).Reference = "";
 
                     r_lev.File_Table.Where(x => x.Label == LABEL_LEVI_ELEVATOR_A).FirstOrDefault().File_Data = g_lev.ToRawData();
@@ -364,7 +384,7 @@ namespace kotor_Randomizer_2
                     r_lev.WriteToFile(fi.FullName);
                 }
 
-                //Commadn Deck Fix
+                // Command Deck Fix
                 foreach (FileInfo fi in lev_files_b)
                 {
                     // Skip any files that don't end in "s.rim".
@@ -373,7 +393,7 @@ namespace kotor_Randomizer_2
                     RIM r_lev = new RIM(fi.FullName);
                     GFF g_lev = new GFF(r_lev.File_Table.Where(x => x.Label == LABEL_LEVI_ELEVATOR_B).FirstOrDefault().File_Data);
 
-                    //Sets the active reference for the hanger option to nothing, meaning there is no requirement to transition to the hanger
+                    // Sets the active reference for the hangar option to nothing, meaning there is no requirement to transition to the hangar
                     (((g_lev.Top_Level.Fields.Where(x => x.Label == "ReplyList").FirstOrDefault() as GFF.LIST).Structs.Where(x => x.Struct_Type == 1).FirstOrDefault().Fields.Where(x => x.Label == "EntriesList").FirstOrDefault() as GFF.LIST).Structs.Where(x => x.Struct_Type == 1).FirstOrDefault().Fields.Where(x => x.Label == "Active").FirstOrDefault() as GFF.ResRef).Reference = "";
 
                     r_lev.File_Table.Where(x => x.Label == LABEL_LEVI_ELEVATOR_B).FirstOrDefault().File_Data = g_lev.ToRawData();
@@ -381,7 +401,7 @@ namespace kotor_Randomizer_2
                     r_lev.WriteToFile(fi.FullName);
                 }
 
-                //Hanger Fix
+                // Hangar Fix
                 foreach (FileInfo fi in lev_files_c)
                 {
                     // Skip any files that don't end in "s.rim".
@@ -389,24 +409,25 @@ namespace kotor_Randomizer_2
 
                     RIM r_lev = new RIM(fi.FullName);
 
-                    //While I possess the ability to edit this file programmatically, due to the complexity I have opted to just load the modded file into resources.
+                    // While I possess the ability to edit this file programmatically, due to the complexity I have opted to just load the modded file into resources.
                     r_lev.File_Table.Where(x => x.Label == LABEL_LEVI_ELEVATOR_C).FirstOrDefault().File_Data = Properties.Resources.lev40_accntl_dlg;
-                    //Adding module transition scripts to RIM
-                    //Prison Block
+
+                    // Adding module transition scripts to RIM...
+                    // Prison Block
                     RIM.rFile to40aa = new RIM.rFile
                     {
                         TypeID = (int)ResourceType.NCS,
                         Label = "k_plev_goto40aa",
                         File_Data = Properties.Resources.k_plev_goto40aa
                     };
-                    //Command Deck
+                    // Command Deck
                     RIM.rFile to40ab = new RIM.rFile
                     {
                         TypeID = (int)ResourceType.NCS,
                         Label = "k_plev_goto40ab",
                         File_Data = Properties.Resources.k_plev_goto40ab
                     };
-                    //adding scripts
+                    // Adding scripts
                     r_lev.File_Table.Add(to40aa);
                     r_lev.File_Table.Add(to40ab);
 
@@ -415,7 +436,7 @@ namespace kotor_Randomizer_2
                 }
             }
 
-            //Vulkar Spice Lab Transition
+            // Vulkar Spice Lab Transition
             if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.VulkarSpiceLZ))
             {
                 var vulk_files = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_VULKAR_BASE]));

--- a/kotor Randomizer 2/Randomization/ModuleRando.cs
+++ b/kotor Randomizer 2/Randomization/ModuleRando.cs
@@ -519,7 +519,7 @@ namespace kotor_Randomizer_2
         /// If no randomization has been performed, no file will be created.
         /// </summary>
         /// <param name="path">Path to desired output file.</param>
-        public static void GenerateSpoilerLog(string path)
+        public static void CreateSpoilerLog(string path)
         {
             if (LookupTable.Count == 0) { return; }
             var sortedLookup = LookupTable.OrderBy(kvp => kvp.Key);
@@ -565,7 +565,7 @@ namespace kotor_Randomizer_2
             }
         }
 
-        public static void GenerateSpoilerLog(XLWorkbook workbook)
+        public static void CreateSpoilerLog(XLWorkbook workbook)
         {
             if (LookupTable.Count == 0) { return; }
             var ws = workbook.Worksheets.Add("Module");
@@ -711,10 +711,8 @@ namespace kotor_Randomizer_2
                 else
                 {
                     // Set color of "Has Changed" column. Booleans are automatically centered.
-                    if (changed)
-                        ws.Cell(i, 1).Style.Font.FontColor = XLColor.Green;
-                    else
-                        ws.Cell(i, 1).Style.Font.FontColor = XLColor.Red;
+                    if (changed) ws.Cell(i, 1).Style.Font.FontColor = XLColor.Green;
+                    else         ws.Cell(i, 1).Style.Font.FontColor = XLColor.Red;
                 }
                 i++;
             }

--- a/kotor Randomizer 2/Randomization/ModuleRando.cs
+++ b/kotor Randomizer 2/Randomization/ModuleRando.cs
@@ -634,12 +634,12 @@ namespace kotor_Randomizer_2
             }
 
             // Custom Omitted Modules
-            int iMax = i;
             var omittedModules = Globals.BoundModules.Where(x => x.Omitted);
 
             if (isCustomPreset)
             {
-                i = 3;
+                int iMax = i;
+                i = 3;  // Restart at the top of the settings list.
 
                 ws.Cell(i, 4).Value = "Omitted Modules";
                 ws.Cell(i, 4).Style.Font.Bold = true;
@@ -661,14 +661,9 @@ namespace kotor_Randomizer_2
                     i++;
                 }
 
-                if (iMax > i)
-                {
-                    i = iMax;   // Return to bottom of settings list.
-                }
-                else
-                {
-                    i++;    // Skip a row.
-                }
+                // Handle variable length omitted modules list.
+                if (iMax > i) i = iMax; // Return to bottom of settings list.
+                else          i++;      // Skip a row.
             }
 
             // Module Shuffle

--- a/kotor Randomizer 2/Randomization/OtherRando.cs
+++ b/kotor Randomizer 2/Randomization/OtherRando.cs
@@ -370,7 +370,7 @@ namespace kotor_Randomizer_2
             }
         }
 
-        internal static void GenerateSpoilerLog(XLWorkbook workbook)
+        internal static void CreateSpoilerLog(XLWorkbook workbook)
         {
             if (NameGenLookup.Count == 0        &&
                 PolymorphLookupTable.Count == 0 &&

--- a/kotor Randomizer 2/Randomization/RandoForm.Designer.cs
+++ b/kotor Randomizer 2/Randomization/RandoForm.Designer.cs
@@ -34,39 +34,42 @@
             this.bDone = new System.Windows.Forms.Button();
             this.bwRandomizing = new System.ComponentModel.BackgroundWorker();
             this.bwUnrandomizing = new System.ComponentModel.BackgroundWorker();
+            this.bwSpoilers = new System.ComponentModel.BackgroundWorker();
+            this.bSpoilers = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // RandomizationProgress
             // 
             this.RandomizationProgress.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.RandomizationProgress.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.RandomizationProgress.Location = new System.Drawing.Point(20, 50);
+            this.RandomizationProgress.Location = new System.Drawing.Point(12, 50);
             this.RandomizationProgress.Name = "RandomizationProgress";
-            this.RandomizationProgress.Size = new System.Drawing.Size(480, 30);
+            this.RandomizationProgress.Size = new System.Drawing.Size(498, 30);
             this.RandomizationProgress.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
             this.RandomizationProgress.TabIndex = 0;
             // 
             // currentRandoTask_label
             // 
-            this.currentRandoTask_label.Font = new System.Drawing.Font("Unispace", 9.749999F, ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Underline))), System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.currentRandoTask_label.Location = new System.Drawing.Point(20, 20);
+            this.currentRandoTask_label.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, ((System.Drawing.FontStyle)((System.Drawing.FontStyle.Bold | System.Drawing.FontStyle.Underline))), System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.currentRandoTask_label.Location = new System.Drawing.Point(12, 18);
             this.currentRandoTask_label.Name = "currentRandoTask_label";
-            this.currentRandoTask_label.Size = new System.Drawing.Size(480, 20);
+            this.currentRandoTask_label.Size = new System.Drawing.Size(498, 20);
             this.currentRandoTask_label.TabIndex = 1;
             this.currentRandoTask_label.Text = "Current Task";
             this.currentRandoTask_label.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // bDone
             // 
+            this.bDone.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.bDone.Enabled = false;
             this.bDone.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.bDone.FlatAppearance.BorderSize = 2;
             this.bDone.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Black;
             this.bDone.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.bDone.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.bDone.Font = new System.Drawing.Font("Unispace", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.bDone.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.bDone.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.bDone.Location = new System.Drawing.Point(200, 90);
+            this.bDone.Location = new System.Drawing.Point(380, 95);
             this.bDone.Name = "bDone";
             this.bDone.Size = new System.Drawing.Size(120, 30);
             this.bDone.TabIndex = 3;
@@ -88,12 +91,40 @@
             this.bwUnrandomizing.ProgressChanged += new System.ComponentModel.ProgressChangedEventHandler(this.bwUnrandomizing_ProgressChanged);
             this.bwUnrandomizing.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this.bwUnrandomizing_RunWorkerCompleted);
             // 
+            // bwSpoilers
+            // 
+            this.bwSpoilers.WorkerReportsProgress = true;
+            this.bwSpoilers.DoWork += new System.ComponentModel.DoWorkEventHandler(this.bwSpoilers_DoWork);
+            this.bwSpoilers.ProgressChanged += new System.ComponentModel.ProgressChangedEventHandler(this.bwSpoilers_ProgressChanged);
+            this.bwSpoilers.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this.bwSpoilers_RunWorkerCompleted);
+            // 
+            // bSpoilers
+            // 
+            this.bSpoilers.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.bSpoilers.Enabled = false;
+            this.bSpoilers.FlatAppearance.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.bSpoilers.FlatAppearance.BorderSize = 2;
+            this.bSpoilers.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Black;
+            this.bSpoilers.FlatAppearance.MouseOverBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
+            this.bSpoilers.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.bSpoilers.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.bSpoilers.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.bSpoilers.Location = new System.Drawing.Point(204, 95);
+            this.bSpoilers.Name = "bSpoilers";
+            this.bSpoilers.Size = new System.Drawing.Size(160, 30);
+            this.bSpoilers.TabIndex = 4;
+            this.bSpoilers.Text = "Open Spoilers Directory";
+            this.bSpoilers.UseVisualStyleBackColor = false;
+            this.bSpoilers.Visible = false;
+            this.bSpoilers.Click += new System.EventHandler(this.bSpoilers_Click);
+            // 
             // RandoForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
-            this.ClientSize = new System.Drawing.Size(521, 141);
+            this.ClientSize = new System.Drawing.Size(522, 141);
+            this.Controls.Add(this.bSpoilers);
             this.Controls.Add(this.bDone);
             this.Controls.Add(this.currentRandoTask_label);
             this.Controls.Add(this.RandomizationProgress);
@@ -114,5 +145,7 @@
         private System.Windows.Forms.Button bDone;
         private System.ComponentModel.BackgroundWorker bwRandomizing;
         private System.ComponentModel.BackgroundWorker bwUnrandomizing;
+        private System.ComponentModel.BackgroundWorker bwSpoilers;
+        private System.Windows.Forms.Button bSpoilers;
     }
 }

--- a/kotor Randomizer 2/Randomization/RandoForm.Designer.cs
+++ b/kotor Randomizer 2/Randomization/RandoForm.Designer.cs
@@ -129,7 +129,9 @@
             this.Controls.Add(this.currentRandoTask_label);
             this.Controls.Add(this.RandomizationProgress);
             this.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MaximizeBox = false;
             this.Name = "RandoForm";
             this.ShowIcon = false;
             this.Text = "Randomizing";

--- a/kotor Randomizer 2/Randomization/RandoForm.Designer.cs
+++ b/kotor Randomizer 2/Randomization/RandoForm.Designer.cs
@@ -69,7 +69,7 @@
             this.bDone.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.bDone.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.bDone.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.bDone.Location = new System.Drawing.Point(380, 95);
+            this.bDone.Location = new System.Drawing.Point(204, 95);
             this.bDone.Name = "bDone";
             this.bDone.Size = new System.Drawing.Size(120, 30);
             this.bDone.TabIndex = 3;
@@ -109,7 +109,7 @@
             this.bSpoilers.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.bSpoilers.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.bSpoilers.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.bSpoilers.Location = new System.Drawing.Point(204, 95);
+            this.bSpoilers.Location = new System.Drawing.Point(344, 95);
             this.bSpoilers.Name = "bSpoilers";
             this.bSpoilers.Size = new System.Drawing.Size(160, 30);
             this.bSpoilers.TabIndex = 4;

--- a/kotor Randomizer 2/Randomization/RandoForm.cs
+++ b/kotor Randomizer 2/Randomization/RandoForm.cs
@@ -505,6 +505,10 @@ namespace kotor_Randomizer_2
                     else bDone.Enabled = true;
                 }
             }
+            else
+            {
+                bDone.Enabled = true;
+            }
         }
 
         // BW Unrandomizing Events

--- a/kotor Randomizer 2/Randomization/RandoForm.cs
+++ b/kotor Randomizer 2/Randomization/RandoForm.cs
@@ -311,35 +311,35 @@ namespace kotor_Randomizer_2
                 {
                     curr_task = "Creating Spoilers - Item";
                     bwSpoilers.ReportProgress(curr_progress);
-                    ItemRando.GenerateSpoilerLog(workbook);
+                    ItemRando.CreateSpoilerLog(workbook);
 
                     curr_task = "Creating Spoilers - Model";
                     bwSpoilers.ReportProgress(curr_progress += step_size);
-                    ModelRando.GenerateSpoilerLog(workbook);
+                    ModelRando.CreateSpoilerLog(workbook);
 
                     curr_task = "Creating Spoilers - Module";
                     bwSpoilers.ReportProgress(curr_progress += step_size);
-                    ModuleRando.GenerateSpoilerLog(workbook);
+                    ModuleRando.CreateSpoilerLog(workbook);
 
                     curr_task = "Creating Spoilers - Music / Sound";
                     bwSpoilers.ReportProgress(curr_progress += step_size);
-                    SoundRando.GenerateSpoilerLog(workbook);
+                    SoundRando.CreateSpoilerLog(workbook);
 
                     curr_task = "Creating Spoilers - Other";
                     bwSpoilers.ReportProgress(curr_progress += step_size);
-                    OtherRando.GenerateSpoilerLog(workbook);
+                    OtherRando.CreateSpoilerLog(workbook);
 
                     curr_task = "Creating Spoilers - Text";
                     bwSpoilers.ReportProgress(curr_progress += step_size);
-                    TextRando.GenerateSpoilerLog(workbook);
+                    TextRando.CreateSpoilerLog(workbook);
 
                     curr_task = "Creating Spoilers - Texture";
                     bwSpoilers.ReportProgress(curr_progress += step_size);
-                    TextureRando.GenerateSpoilerLog(workbook);
+                    TextureRando.CreateSpoilerLog(workbook);
 
                     curr_task = "Creating Spoilers - 2DA";
                     bwSpoilers.ReportProgress(curr_progress += step_size);
-                    TwodaRandom.GenerateSpoilerLog(workbook);
+                    TwodaRandom.CreateSpoilerLog(workbook);
 
                     curr_task = "Creating Spoilers - Saving File";
                     bwSpoilers.ReportProgress(curr_progress += step_size);
@@ -370,7 +370,6 @@ namespace kotor_Randomizer_2
                 SpoilerCreated = false;
                 SpoilerMessage = $"Exception caught while creating spoilers: {e.ToString()}";
             }
-
         }
 
         private void ResetRandomizationCategories()

--- a/kotor Randomizer 2/Randomization/RandoForm.resx
+++ b/kotor Randomizer 2/Randomization/RandoForm.resx
@@ -123,6 +123,9 @@
   <metadata name="bwUnrandomizing.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>156, 17</value>
   </metadata>
+  <metadata name="bwSpoilers.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>297, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/kotor Randomizer 2/Randomization/SoundRando.cs
+++ b/kotor Randomizer 2/Randomization/SoundRando.cs
@@ -370,7 +370,7 @@ namespace kotor_Randomizer_2
             }
         }
 
-        public static void GenerateSpoilerLog(XLWorkbook workbook)
+        public static void CreateSpoilerLog(XLWorkbook workbook)
         {
             if (MusicLookupTable.Count == 0 &&
                 SoundLookupTable.Count == 0)

--- a/kotor Randomizer 2/Randomization/TextRando.cs
+++ b/kotor Randomizer 2/Randomization/TextRando.cs
@@ -218,7 +218,7 @@ namespace kotor_Randomizer_2
             RepliesLookupTable.Clear();
         }
 
-        internal static void GenerateSpoilerLog(XLWorkbook workbook)
+        internal static void CreateSpoilerLog(XLWorkbook workbook)
         {
             if (TlkLookupTable.Count == 0     &&
                 EntriesLookupTable.Count == 0 &&

--- a/kotor Randomizer 2/Randomization/TextureRando.cs
+++ b/kotor Randomizer 2/Randomization/TextureRando.cs
@@ -188,7 +188,7 @@ namespace kotor_Randomizer_2
             NameLookup.Clear();
         }
 
-        internal static void GenerateSpoilerLog(XLWorkbook workbook)
+        internal static void CreateSpoilerLog(XLWorkbook workbook)
         {
             if (LookupTable.Count == 0) { return; }
             var ws = workbook.Worksheets.Add("Texture");

--- a/kotor Randomizer 2/Randomization/TwodaRandom.cs
+++ b/kotor Randomizer 2/Randomization/TwodaRandom.cs
@@ -58,7 +58,7 @@ namespace kotor_Randomizer_2
             LookupTable.Clear();
         }
 
-        internal static void GenerateSpoilerLog(XLWorkbook workbook)
+        internal static void CreateSpoilerLog(XLWorkbook workbook)
         {
             if (LookupTable.Count == 0) { return; }
             var ws = workbook.Worksheets.Add("TwoDA");


### PR DESCRIPTION
Fixes #40, #47, #48, #49, #51, #52, and #53. Once this is merged, I will publish the release v2.5.2.

- *General*
  - Added third version number to StartForm title.
  - #47: Typos fixed.
  - #48: Spoiler creation was moved to be only available right after randomizing.
  - Auto Create Spoiler setting added to the contextual popup menu on StartForm.
  - #40: The change for #48 also means that the logged settings will be almost always up to date.
  - #52: Now checks to see if the game is already randomized whenever the KotOR path is modified.
- *Modules*
  - Organized the module setting page and added an "Off" preset to the preset list.
  - #49: Modules will not be randomized or have reachability tested if no more than 1 module is included.
  - #53: Added preset and custom omitted modules to the spoilers.
- *Items*
  - #51: Added "Clothing Variant 4" to the default omitted items list.