### PR TITLE
Unlock doors fix #55

### DIFF
--- a/kotor Randomizer 2/Digraph.cs
+++ b/kotor Randomizer 2/Digraph.cs
@@ -64,10 +64,15 @@ namespace kotor_Randomizer_2
 
         // Fix Tags ... Edge (Tags)
         public const string TAG_FIX_BOX   = "FixBox";
-        public const string TAG_FIX_DOORS = "FixDoors";
         public const string TAG_FIX_ELEV  = "FixElev";
         public const string TAG_FIX_MAP   = "FixMap";
         public const string TAG_FIX_SPICE = "FixSpice";
+
+        // Unlock Tags ... Edge (Tags)
+        public const string TAG_UNLOCK_DAN_RUINS   = "UL_Ruins";
+        public const string TAG_UNLOCK_MAN_SUB     = "UL_Sub";
+        public const string TAG_UNLOCK_STA_BASTILA = "UL_Deck3";
+        public const string TAG_UNLOCK_UNK_SUMMIT  = "UL_Summit";
     }
 
     /// <summary>
@@ -110,14 +115,21 @@ namespace kotor_Randomizer_2
 
         /// <summary> FixBox is enabled for this randomization. Locked and Once tags will be ignored on the same edge. </summary>
         public bool EnabledFixBox   { get; set; } = false;
-        /// <summary> FixDoors is enabled for this randomization. Locked and Once tags will be ignored on the same edge. </summary>
-        public bool EnabledFixDoors { get; set; } = false;
         /// <summary> FixElev is enabled for this randomization. Locked and Once tags will be ignored on the same edge. </summary>
         public bool EnabledFixElev  { get; set; } = false;
         /// <summary> FixMap is enabled for this randomization. Locked and Once tags will be ignored on the same edge. </summary>
         public bool EnabledFixMap   { get; set; } = false;
         /// <summary> FixSpice is enabled for this randomization. Locked and Once tags will be ignored on the same edge. </summary>
         public bool EnabledFixSpice { get; set; } = false;
+
+        /// <summary> UnlockDanRuins is enabled for this randomization. Locked and Once tags will be ignored on the same edge. </summary>
+        public bool EnabledUnlockDanRuins   { get; set; } = false;
+        /// <summary> UnlockManSub is enabled for this randomization. Locked and Once tags will be ignored on the same edge. </summary>
+        public bool EnabledUnlockManSub     { get; set; } = false;
+        /// <summary> UnlockStaBastila is enabled for this randomization. Locked and Once tags will be ignored on the same edge. </summary>
+        public bool EnabledUnlockStaBastila { get; set; } = false;
+        /// <summary> UnlockUnkSummit is enabled for this randomization. Locked and Once tags will be ignored on the same edge. </summary>
+        public bool EnabledUnlockUnkSummit  { get; set; } = false;
         #endregion
 
         /// <summary>
@@ -136,20 +148,7 @@ namespace kotor_Randomizer_2
             RandomLookup = Modules.ToDictionary(m => m.WarpCode, m => m.WarpCode);
 
             // Get currently enabled settings.
-            AllowGlitchClip = Properties.Settings.Default.AllowGlitchClip;
-            AllowGlitchDlz = Properties.Settings.Default.AllowGlitchDlz;
-            AllowGlitchFlu = Properties.Settings.Default.AllowGlitchFlu;
-            AllowGlitchGpw = Properties.Settings.Default.AllowGlitchGpw;
-            EnabledFixBox = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixMindPrison);
-            EnabledFixDoors = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockVarDoors);
-            EnabledFixElev = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators);
-            EnabledFixMap = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockGalaxyMap);
-            EnabledFixSpice = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.VulkarSpiceLZ);
-            EnforceEdgeTagLocked = true;
-            IgnoreOnceEdges = Properties.Settings.Default.IgnoreOnceEdges;
-            GoalIsMalak = Properties.Settings.Default.GoalIsMalak;
-            GoalIsPazaak = Properties.Settings.Default.GoalIsPazaak;
-            GoalIsStarMap = Properties.Settings.Default.GoalIsStarMaps;
+            ResetSettings();
         }
 
         public void ResetSettings()
@@ -160,10 +159,13 @@ namespace kotor_Randomizer_2
             AllowGlitchFlu = Properties.Settings.Default.AllowGlitchFlu;
             AllowGlitchGpw = Properties.Settings.Default.AllowGlitchGpw;
             EnabledFixBox = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixMindPrison);
-            EnabledFixDoors = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockVarDoors);
-            EnabledFixElev = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators);
+            EnabledFixElev = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockLevElev);
             EnabledFixMap = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockGalaxyMap);
             EnabledFixSpice = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.VulkarSpiceLZ);
+            EnabledUnlockDanRuins = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockDanRuins);
+            EnabledUnlockManSub = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockManSub);
+            EnabledUnlockStaBastila = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockStaBastila);
+            EnabledUnlockUnkSummit = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockUnkSummit);
             EnforceEdgeTagLocked = true;
             IgnoreOnceEdges = Properties.Settings.Default.IgnoreOnceEdges;
             GoalIsMalak = Properties.Settings.Default.GoalIsMalak;
@@ -387,11 +389,14 @@ namespace kotor_Randomizer_2
             bool isOnce = false;
             if (edge.IsOnce)
             {
-                if ((EnabledFixBox && edge.IsFixBox    ) ||
-                    (EnabledFixDoors && edge.IsFixDoors) ||
-                    (EnabledFixElev && edge.IsFixElev  ) ||
-                    (EnabledFixMap && edge.IsFixMap    ) ||
-                    (EnabledFixSpice && edge.IsFixSpice))
+                if ((EnabledFixBox           && edge.IsFixBox          ) ||
+                    (EnabledFixElev          && edge.IsFixElev         ) ||
+                    (EnabledFixMap           && edge.IsFixMap          ) ||
+                    (EnabledFixSpice         && edge.IsFixSpice        ) ||
+                    (EnabledUnlockDanRuins   && edge.IsUnlockDanRuins  ) ||
+                    (EnabledUnlockManSub     && edge.IsUnlockManSub    ) ||
+                    (EnabledUnlockStaBastila && edge.IsUnlockStaBastila) ||
+                    (EnabledUnlockUnkSummit  && edge.IsUnlockUnkSummit ))
                 {
                     isOnce = false;
                 }
@@ -419,15 +424,18 @@ namespace kotor_Randomizer_2
             if (edge.IsLocked)
             {
                 // Check to see if we can bypass this lock with an allowed glitch or enabled fix.
-                if ((AllowGlitchClip && edge.IsClip    ) ||
-                    (AllowGlitchDlz && edge.IsDlz      ) ||
-                    (AllowGlitchFlu && edge.IsFlu      ) || // How to handle FluReq? One FLU still requires Carth...
-                    (AllowGlitchGpw && edge.IsGpw      ) ||
-                    (EnabledFixBox && edge.IsFixBox    ) ||
-                    (EnabledFixDoors && edge.IsFixDoors) ||
-                    (EnabledFixElev && edge.IsFixElev  ) ||
-                    (EnabledFixMap && edge.IsFixMap    ) ||
-                    (EnabledFixSpice && edge.IsFixSpice))
+                if ((AllowGlitchClip         && edge.IsClip            ) ||
+                    (AllowGlitchDlz          && edge.IsDlz             ) ||
+                    (AllowGlitchFlu          && edge.IsFlu             ) || // How to handle FluReq? One FLU still requires Carth...
+                    (AllowGlitchGpw          && edge.IsGpw             ) ||
+                    (EnabledFixBox           && edge.IsFixBox          ) ||
+                    (EnabledFixElev          && edge.IsFixElev         ) ||
+                    (EnabledFixMap           && edge.IsFixMap          ) ||
+                    (EnabledFixSpice         && edge.IsFixSpice        ) ||
+                    (EnabledUnlockDanRuins   && edge.IsUnlockDanRuins  ) ||
+                    (EnabledUnlockManSub     && edge.IsUnlockManSub    ) ||
+                    (EnabledUnlockStaBastila && edge.IsUnlockStaBastila) ||
+                    (EnabledUnlockUnkSummit  && edge.IsUnlockUnkSummit ))
                 {
                     isLocked = false;
                 }
@@ -692,10 +700,14 @@ namespace kotor_Randomizer_2
         public bool IsGpw { get; } = false;
 
         public bool IsFixBox   { get; } = false;
-        public bool IsFixDoors { get; } = false;
         public bool IsFixElev  { get; } = false;
         public bool IsFixMap   { get; } = false;
         public bool IsFixSpice { get; } = false;
+
+        public bool IsUnlockDanRuins   { get; } = false;
+        public bool IsUnlockManSub     { get; } = false;
+        public bool IsUnlockStaBastila { get; } = false;
+        public bool IsUnlockUnkSummit  { get; } = false;
 
         public List<string> Tags { get; } = new List<string>();
 
@@ -758,10 +770,14 @@ namespace kotor_Randomizer_2
             IsGpw = Tags.Contains(XmlConsts.TAG_GPW);
 
             IsFixBox   = Tags.Contains(XmlConsts.TAG_FIX_BOX);
-            IsFixDoors = Tags.Contains(XmlConsts.TAG_FIX_DOORS);
             IsFixElev  = Tags.Contains(XmlConsts.TAG_FIX_ELEV);
             IsFixMap   = Tags.Contains(XmlConsts.TAG_FIX_MAP);
             IsFixSpice = Tags.Contains(XmlConsts.TAG_FIX_SPICE);
+
+            IsUnlockDanRuins   = Tags.Contains(XmlConsts.TAG_UNLOCK_DAN_RUINS);
+            IsUnlockManSub     = Tags.Contains(XmlConsts.TAG_UNLOCK_MAN_SUB);
+            IsUnlockStaBastila = Tags.Contains(XmlConsts.TAG_UNLOCK_STA_BASTILA);
+            IsUnlockUnkSummit  = Tags.Contains(XmlConsts.TAG_UNLOCK_UNK_SUMMIT);
         }
 
         public override string ToString()

--- a/kotor Randomizer 2/Forms/ModuleForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/ModuleForm.Designer.cs
@@ -66,8 +66,6 @@
             this.lblWIP = new System.Windows.Forms.Label();
             this.lblSaveData = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
-            this.pnlSaveData = new System.Windows.Forms.Panel();
-            this.pnlTimeSavers = new System.Windows.Forms.Panel();
             this.panel2 = new System.Windows.Forms.Panel();
             this.lblShuffleSettings = new System.Windows.Forms.Label();
             this.lblGeneralSettings = new System.Windows.Forms.Label();
@@ -76,11 +74,13 @@
             this.pnlGlitches = new System.Windows.Forms.Panel();
             this.pnlOther = new System.Windows.Forms.Panel();
             this.label1 = new System.Windows.Forms.Label();
-            this.pnlSaveData.SuspendLayout();
-            this.pnlTimeSavers.SuspendLayout();
+            this.flpSaveData = new System.Windows.Forms.FlowLayoutPanel();
+            this.flpTimeSavers = new System.Windows.Forms.FlowLayoutPanel();
             this.pnlGoals.SuspendLayout();
             this.pnlGlitches.SuspendLayout();
             this.pnlOther.SuspendLayout();
+            this.flpSaveData.SuspendLayout();
+            this.flpTimeSavers.SuspendLayout();
             this.SuspendLayout();
             // 
             // OmittedListBox
@@ -90,10 +90,10 @@
             this.OmittedListBox.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.OmittedListBox.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.OmittedListBox.FormattingEnabled = true;
-            this.OmittedListBox.Location = new System.Drawing.Point(287, 240);
+            this.OmittedListBox.Location = new System.Drawing.Point(287, 255);
             this.OmittedListBox.Name = "OmittedListBox";
             this.OmittedListBox.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
-            this.OmittedListBox.Size = new System.Drawing.Size(248, 312);
+            this.OmittedListBox.Size = new System.Drawing.Size(248, 299);
             this.OmittedListBox.TabIndex = 13;
             this.OmittedListBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.OmittedListBox_KeyPress);
             this.OmittedListBox.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.OmittedListBox_MouseDoubleClick);
@@ -105,10 +105,10 @@
             this.RandomizedListBox.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.RandomizedListBox.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.RandomizedListBox.FormattingEnabled = true;
-            this.RandomizedListBox.Location = new System.Drawing.Point(20, 240);
+            this.RandomizedListBox.Location = new System.Drawing.Point(20, 255);
             this.RandomizedListBox.Name = "RandomizedListBox";
             this.RandomizedListBox.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
-            this.RandomizedListBox.Size = new System.Drawing.Size(248, 312);
+            this.RandomizedListBox.Size = new System.Drawing.Size(248, 299);
             this.RandomizedListBox.TabIndex = 12;
             this.RandomizedListBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.RandomizedListBox_KeyPress);
             this.RandomizedListBox.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.RandomizedListBox_MouseDoubleClick);
@@ -120,7 +120,7 @@
             this.PresetComboBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.PresetComboBox.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.PresetComboBox.FormattingEnabled = true;
-            this.PresetComboBox.Location = new System.Drawing.Point(71, 191);
+            this.PresetComboBox.Location = new System.Drawing.Point(71, 206);
             this.PresetComboBox.Name = "PresetComboBox";
             this.PresetComboBox.Size = new System.Drawing.Size(197, 21);
             this.PresetComboBox.TabIndex = 11;
@@ -133,7 +133,7 @@
             this.cbDeleteMilestones.Checked = true;
             this.cbDeleteMilestones.CheckState = System.Windows.Forms.CheckState.Checked;
             this.cbDeleteMilestones.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbDeleteMilestones.Location = new System.Drawing.Point(9, 7);
+            this.cbDeleteMilestones.Location = new System.Drawing.Point(7, 5);
             this.cbDeleteMilestones.Name = "cbDeleteMilestones";
             this.cbDeleteMilestones.Size = new System.Drawing.Size(159, 17);
             this.cbDeleteMilestones.TabIndex = 1;
@@ -146,7 +146,7 @@
             // 
             this.lblPresets.AutoSize = true;
             this.lblPresets.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.lblPresets.Location = new System.Drawing.Point(20, 194);
+            this.lblPresets.Location = new System.Drawing.Point(20, 209);
             this.lblPresets.Name = "lblPresets";
             this.lblPresets.Size = new System.Drawing.Size(45, 13);
             this.lblPresets.TabIndex = 20;
@@ -156,7 +156,7 @@
             // 
             this.cbSaveAllMods.AutoSize = true;
             this.cbSaveAllMods.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbSaveAllMods.Location = new System.Drawing.Point(9, 53);
+            this.cbSaveAllMods.Location = new System.Drawing.Point(7, 51);
             this.cbSaveAllMods.Name = "cbSaveAllMods";
             this.cbSaveAllMods.Size = new System.Drawing.Size(157, 17);
             this.cbSaveAllMods.TabIndex = 3;
@@ -170,7 +170,7 @@
             // 
             this.cbSaveMiniGame.AutoSize = true;
             this.cbSaveMiniGame.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbSaveMiniGame.Location = new System.Drawing.Point(9, 30);
+            this.cbSaveMiniGame.Location = new System.Drawing.Point(7, 28);
             this.cbSaveMiniGame.Name = "cbSaveMiniGame";
             this.cbSaveMiniGame.Size = new System.Drawing.Size(153, 17);
             this.cbSaveMiniGame.TabIndex = 2;
@@ -185,7 +185,7 @@
             // 
             this.lblRandomized.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblRandomized.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.lblRandomized.Location = new System.Drawing.Point(20, 219);
+            this.lblRandomized.Location = new System.Drawing.Point(20, 234);
             this.lblRandomized.Name = "lblRandomized";
             this.lblRandomized.Size = new System.Drawing.Size(248, 14);
             this.lblRandomized.TabIndex = 23;
@@ -196,7 +196,7 @@
             // 
             this.lblOmitted.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblOmitted.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.lblOmitted.Location = new System.Drawing.Point(287, 219);
+            this.lblOmitted.Location = new System.Drawing.Point(287, 234);
             this.lblOmitted.Name = "lblOmitted";
             this.lblOmitted.Size = new System.Drawing.Size(248, 14);
             this.lblOmitted.TabIndex = 24;
@@ -207,7 +207,7 @@
             // 
             this.cbFixDream.AutoSize = true;
             this.cbFixDream.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbFixDream.Location = new System.Drawing.Point(9, 7);
+            this.cbFixDream.Location = new System.Drawing.Point(7, 28);
             this.cbFixDream.Name = "cbFixDream";
             this.cbFixDream.Size = new System.Drawing.Size(125, 17);
             this.cbFixDream.TabIndex = 4;
@@ -220,7 +220,7 @@
             // 
             this.cbUnlockGalaxyMap.AutoSize = true;
             this.cbUnlockGalaxyMap.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbUnlockGalaxyMap.Location = new System.Drawing.Point(155, 30);
+            this.cbUnlockGalaxyMap.Location = new System.Drawing.Point(164, 5);
             this.cbUnlockGalaxyMap.Name = "cbUnlockGalaxyMap";
             this.cbUnlockGalaxyMap.Size = new System.Drawing.Size(119, 17);
             this.cbUnlockGalaxyMap.TabIndex = 9;
@@ -233,7 +233,7 @@
             // 
             this.cbFixCoordinates.AutoSize = true;
             this.cbFixCoordinates.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbFixCoordinates.Location = new System.Drawing.Point(9, 53);
+            this.cbFixCoordinates.Location = new System.Drawing.Point(7, 74);
             this.cbFixCoordinates.Name = "cbFixCoordinates";
             this.cbFixCoordinates.Size = new System.Drawing.Size(136, 17);
             this.cbFixCoordinates.TabIndex = 6;
@@ -246,7 +246,7 @@
             // 
             this.cbFixMindPrison.AutoSize = true;
             this.cbFixMindPrison.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbFixMindPrison.Location = new System.Drawing.Point(9, 30);
+            this.cbFixMindPrison.Location = new System.Drawing.Point(7, 51);
             this.cbFixMindPrison.Name = "cbFixMindPrison";
             this.cbFixMindPrison.Size = new System.Drawing.Size(97, 17);
             this.cbFixMindPrison.TabIndex = 5;
@@ -259,7 +259,7 @@
             // 
             this.cbDoorFix.AutoSize = true;
             this.cbDoorFix.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbDoorFix.Location = new System.Drawing.Point(155, 53);
+            this.cbDoorFix.Location = new System.Drawing.Point(164, 28);
             this.cbDoorFix.Name = "cbDoorFix";
             this.cbDoorFix.Size = new System.Drawing.Size(129, 17);
             this.cbDoorFix.TabIndex = 10;
@@ -273,7 +273,7 @@
             // 
             this.cbFixLevElevators.AutoSize = true;
             this.cbFixLevElevators.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbFixLevElevators.Location = new System.Drawing.Point(9, 76);
+            this.cbFixLevElevators.Location = new System.Drawing.Point(7, 97);
             this.cbFixLevElevators.Name = "cbFixLevElevators";
             this.cbFixLevElevators.Size = new System.Drawing.Size(136, 17);
             this.cbFixLevElevators.TabIndex = 7;
@@ -287,7 +287,7 @@
             // 
             this.cbVulkSpiceLZ.AutoSize = true;
             this.cbVulkSpiceLZ.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbVulkSpiceLZ.Location = new System.Drawing.Point(155, 7);
+            this.cbVulkSpiceLZ.Location = new System.Drawing.Point(7, 5);
             this.cbVulkSpiceLZ.Name = "cbVulkSpiceLZ";
             this.cbVulkSpiceLZ.Size = new System.Drawing.Size(151, 17);
             this.cbVulkSpiceLZ.TabIndex = 8;
@@ -556,36 +556,10 @@
             this.label3.Text = "Time Savers / Quality of Life";
             this.label3.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
-            // pnlSaveData
-            // 
-            this.pnlSaveData.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
-            this.pnlSaveData.Controls.Add(this.cbDeleteMilestones);
-            this.pnlSaveData.Controls.Add(this.cbSaveAllMods);
-            this.pnlSaveData.Controls.Add(this.cbSaveMiniGame);
-            this.pnlSaveData.Location = new System.Drawing.Point(20, 49);
-            this.pnlSaveData.Name = "pnlSaveData";
-            this.pnlSaveData.Size = new System.Drawing.Size(179, 79);
-            this.pnlSaveData.TabIndex = 58;
-            // 
-            // pnlTimeSavers
-            // 
-            this.pnlTimeSavers.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
-            this.pnlTimeSavers.Controls.Add(this.cbFixDream);
-            this.pnlTimeSavers.Controls.Add(this.cbUnlockGalaxyMap);
-            this.pnlTimeSavers.Controls.Add(this.cbFixCoordinates);
-            this.pnlTimeSavers.Controls.Add(this.cbFixMindPrison);
-            this.pnlTimeSavers.Controls.Add(this.cbDoorFix);
-            this.pnlTimeSavers.Controls.Add(this.cbVulkSpiceLZ);
-            this.pnlTimeSavers.Controls.Add(this.cbFixLevElevators);
-            this.pnlTimeSavers.Location = new System.Drawing.Point(223, 49);
-            this.pnlTimeSavers.Name = "pnlTimeSavers";
-            this.pnlTimeSavers.Size = new System.Drawing.Size(312, 100);
-            this.pnlTimeSavers.TabIndex = 59;
-            // 
             // panel2
             // 
             this.panel2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.panel2.Location = new System.Drawing.Point(20, 159);
+            this.panel2.Location = new System.Drawing.Point(20, 174);
             this.panel2.Name = "panel2";
             this.panel2.Size = new System.Drawing.Size(515, 2);
             this.panel2.TabIndex = 60;
@@ -594,7 +568,7 @@
             // 
             this.lblShuffleSettings.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblShuffleSettings.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.lblShuffleSettings.Location = new System.Drawing.Point(20, 166);
+            this.lblShuffleSettings.Location = new System.Drawing.Point(20, 181);
             this.lblShuffleSettings.Name = "lblShuffleSettings";
             this.lblShuffleSettings.Size = new System.Drawing.Size(515, 18);
             this.lblShuffleSettings.TabIndex = 54;
@@ -667,12 +641,44 @@
             this.label1.TabIndex = 66;
             this.label1.Text = "Other settings:";
             // 
+            // flpSaveData
+            // 
+            this.flpSaveData.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
+            this.flpSaveData.Controls.Add(this.cbDeleteMilestones);
+            this.flpSaveData.Controls.Add(this.cbSaveMiniGame);
+            this.flpSaveData.Controls.Add(this.cbSaveAllMods);
+            this.flpSaveData.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flpSaveData.Location = new System.Drawing.Point(20, 49);
+            this.flpSaveData.Name = "flpSaveData";
+            this.flpSaveData.Padding = new System.Windows.Forms.Padding(4, 2, 2, 2);
+            this.flpSaveData.Size = new System.Drawing.Size(179, 73);
+            this.flpSaveData.TabIndex = 67;
+            // 
+            // flpTimeSavers
+            // 
+            this.flpTimeSavers.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
+            this.flpTimeSavers.Controls.Add(this.cbVulkSpiceLZ);
+            this.flpTimeSavers.Controls.Add(this.cbFixDream);
+            this.flpTimeSavers.Controls.Add(this.cbFixMindPrison);
+            this.flpTimeSavers.Controls.Add(this.cbFixCoordinates);
+            this.flpTimeSavers.Controls.Add(this.cbFixLevElevators);
+            this.flpTimeSavers.Controls.Add(this.cbUnlockGalaxyMap);
+            this.flpTimeSavers.Controls.Add(this.cbDoorFix);
+            this.flpTimeSavers.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flpTimeSavers.Location = new System.Drawing.Point(226, 49);
+            this.flpTimeSavers.Name = "flpTimeSavers";
+            this.flpTimeSavers.Padding = new System.Windows.Forms.Padding(4, 2, 2, 2);
+            this.flpTimeSavers.Size = new System.Drawing.Size(309, 119);
+            this.flpTimeSavers.TabIndex = 68;
+            // 
             // ModuleForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
             this.ClientSize = new System.Drawing.Size(556, 752);
+            this.Controls.Add(this.flpTimeSavers);
+            this.Controls.Add(this.flpSaveData);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.pnlOther);
             this.Controls.Add(this.pnlGlitches);
@@ -684,9 +690,7 @@
             this.Controls.Add(this.lblWIP);
             this.Controls.Add(this.panel2);
             this.Controls.Add(this.RandomizedListBox);
-            this.Controls.Add(this.pnlTimeSavers);
             this.Controls.Add(this.lblRule3);
-            this.Controls.Add(this.pnlSaveData);
             this.Controls.Add(this.OmittedListBox);
             this.Controls.Add(this.lblRule2);
             this.Controls.Add(this.PresetComboBox);
@@ -708,16 +712,16 @@
             this.Text = "Modules";
             this.Activated += new System.EventHandler(this.ModuleForm_Activated);
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.ModuleForm_FormClosing);
-            this.pnlSaveData.ResumeLayout(false);
-            this.pnlSaveData.PerformLayout();
-            this.pnlTimeSavers.ResumeLayout(false);
-            this.pnlTimeSavers.PerformLayout();
             this.pnlGoals.ResumeLayout(false);
             this.pnlGoals.PerformLayout();
             this.pnlGlitches.ResumeLayout(false);
             this.pnlGlitches.PerformLayout();
             this.pnlOther.ResumeLayout(false);
             this.pnlOther.PerformLayout();
+            this.flpSaveData.ResumeLayout(false);
+            this.flpSaveData.PerformLayout();
+            this.flpTimeSavers.ResumeLayout(false);
+            this.flpTimeSavers.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -760,8 +764,6 @@
         private System.Windows.Forms.Label lblWIP;
         private System.Windows.Forms.Label lblSaveData;
         private System.Windows.Forms.Label label3;
-        private System.Windows.Forms.Panel pnlSaveData;
-        private System.Windows.Forms.Panel pnlTimeSavers;
         private System.Windows.Forms.Panel panel2;
         private System.Windows.Forms.Label lblShuffleSettings;
         private System.Windows.Forms.Label lblGeneralSettings;
@@ -770,5 +772,7 @@
         private System.Windows.Forms.Panel pnlGlitches;
         private System.Windows.Forms.Panel pnlOther;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.FlowLayoutPanel flpSaveData;
+        private System.Windows.Forms.FlowLayoutPanel flpTimeSavers;
     }
 }

--- a/kotor Randomizer 2/Forms/ModuleForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/ModuleForm.Designer.cs
@@ -43,8 +43,8 @@
             this.cbUnlockGalaxyMap = new System.Windows.Forms.CheckBox();
             this.cbFixCoordinates = new System.Windows.Forms.CheckBox();
             this.cbFixMindPrison = new System.Windows.Forms.CheckBox();
-            this.cbDoorFix = new System.Windows.Forms.CheckBox();
-            this.cbFixLevElevators = new System.Windows.Forms.CheckBox();
+            this.cbUnlockDanRuins = new System.Windows.Forms.CheckBox();
+            this.cbUnlockLevElevators = new System.Windows.Forms.CheckBox();
             this.cbVulkSpiceLZ = new System.Windows.Forms.CheckBox();
             this.cbReachability = new System.Windows.Forms.CheckBox();
             this.lblGoals = new System.Windows.Forms.Label();
@@ -76,6 +76,9 @@
             this.label1 = new System.Windows.Forms.Label();
             this.flpSaveData = new System.Windows.Forms.FlowLayoutPanel();
             this.flpTimeSavers = new System.Windows.Forms.FlowLayoutPanel();
+            this.cbUnlockManSub = new System.Windows.Forms.CheckBox();
+            this.cbUnlockStaBastila = new System.Windows.Forms.CheckBox();
+            this.cbUnlockUnkSummit = new System.Windows.Forms.CheckBox();
             this.pnlGoals.SuspendLayout();
             this.pnlGlitches.SuspendLayout();
             this.pnlOther.SuspendLayout();
@@ -222,9 +225,9 @@
             this.cbUnlockGalaxyMap.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.cbUnlockGalaxyMap.Location = new System.Drawing.Point(164, 5);
             this.cbUnlockGalaxyMap.Name = "cbUnlockGalaxyMap";
-            this.cbUnlockGalaxyMap.Size = new System.Drawing.Size(119, 17);
+            this.cbUnlockGalaxyMap.Size = new System.Drawing.Size(144, 17);
             this.cbUnlockGalaxyMap.TabIndex = 9;
-            this.cbUnlockGalaxyMap.Text = "Unlock Galaxy Map";
+            this.cbUnlockGalaxyMap.Text = "Unlock EBO Galaxy Map";
             this.ModulesToolTip.SetToolTip(this.cbUnlockGalaxyMap, "Unlock all destinations on the Ebon Hawk galaxy map from\r\nthe start of the game.");
             this.cbUnlockGalaxyMap.UseVisualStyleBackColor = true;
             this.cbUnlockGalaxyMap.CheckedChanged += new System.EventHandler(this.cbUnlockGalaxyMap_CheckedChanged);
@@ -255,33 +258,33 @@
             this.cbFixMindPrison.UseVisualStyleBackColor = true;
             this.cbFixMindPrison.CheckedChanged += new System.EventHandler(this.cbFixMindPrison_CheckedChanged);
             // 
-            // cbDoorFix
+            // cbUnlockDanRuins
             // 
-            this.cbDoorFix.AutoSize = true;
-            this.cbDoorFix.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbDoorFix.Location = new System.Drawing.Point(164, 28);
-            this.cbDoorFix.Name = "cbDoorFix";
-            this.cbDoorFix.Size = new System.Drawing.Size(129, 17);
-            this.cbDoorFix.TabIndex = 10;
-            this.cbDoorFix.Text = "Unlock Various Doors";
-            this.ModulesToolTip.SetToolTip(this.cbDoorFix, "Unlocks the door into the Dantooine Ruins and the door\r\nout of the Unknown World\'" +
+            this.cbUnlockDanRuins.AutoSize = true;
+            this.cbUnlockDanRuins.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.cbUnlockDanRuins.Location = new System.Drawing.Point(7, 97);
+            this.cbUnlockDanRuins.Name = "cbUnlockDanRuins";
+            this.cbUnlockDanRuins.Size = new System.Drawing.Size(142, 17);
+            this.cbUnlockDanRuins.TabIndex = 10;
+            this.cbUnlockDanRuins.Text = "Unlock DAN Ruins Door";
+            this.ModulesToolTip.SetToolTip(this.cbUnlockDanRuins, "Unlocks the door into the Dantooine Ruins and the door\r\nout of the Unknown World\'" +
         "s Temple Summit.");
-            this.cbDoorFix.UseVisualStyleBackColor = true;
-            this.cbDoorFix.CheckedChanged += new System.EventHandler(this.cbDoorFix_CheckedChanged);
+            this.cbUnlockDanRuins.UseVisualStyleBackColor = true;
+            this.cbUnlockDanRuins.CheckedChanged += new System.EventHandler(this.cbUnlockDanRuins_CheckedChanged);
             // 
-            // cbFixLevElevators
+            // cbUnlockLevElevators
             // 
-            this.cbFixLevElevators.AutoSize = true;
-            this.cbFixLevElevators.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.cbFixLevElevators.Location = new System.Drawing.Point(7, 97);
-            this.cbFixLevElevators.Name = "cbFixLevElevators";
-            this.cbFixLevElevators.Size = new System.Drawing.Size(136, 17);
-            this.cbFixLevElevators.TabIndex = 7;
-            this.cbFixLevElevators.Text = "Fix Leviathan Elevators";
-            this.ModulesToolTip.SetToolTip(this.cbFixLevElevators, "The Leviathan elevator will not restrict you from going to\r\nthe Hangar early, and" +
+            this.cbUnlockLevElevators.AutoSize = true;
+            this.cbUnlockLevElevators.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.cbUnlockLevElevators.Location = new System.Drawing.Point(164, 28);
+            this.cbUnlockLevElevators.Name = "cbUnlockLevElevators";
+            this.cbUnlockLevElevators.Size = new System.Drawing.Size(130, 17);
+            this.cbUnlockLevElevators.TabIndex = 7;
+            this.cbUnlockLevElevators.Text = "Unlock LEV Elevators";
+            this.ModulesToolTip.SetToolTip(this.cbUnlockLevElevators, "The Leviathan elevator will not restrict you from going to\r\nthe Hangar early, and" +
         " the Hangar elevator is now usable.");
-            this.cbFixLevElevators.UseVisualStyleBackColor = true;
-            this.cbFixLevElevators.CheckedChanged += new System.EventHandler(this.cbFixLevElevators_CheckedChanged);
+            this.cbUnlockLevElevators.UseVisualStyleBackColor = true;
+            this.cbUnlockLevElevators.CheckedChanged += new System.EventHandler(this.cbUnlockLevElevators_CheckedChanged);
             // 
             // cbVulkSpiceLZ
             // 
@@ -539,7 +542,7 @@
             this.lblSaveData.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
             this.lblSaveData.Location = new System.Drawing.Point(20, 30);
             this.lblSaveData.Name = "lblSaveData";
-            this.lblSaveData.Size = new System.Drawing.Size(179, 14);
+            this.lblSaveData.Size = new System.Drawing.Size(170, 14);
             this.lblSaveData.TabIndex = 55;
             this.lblSaveData.Text = "Save Data";
             this.lblSaveData.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -549,9 +552,9 @@
             // 
             this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
-            this.label3.Location = new System.Drawing.Point(223, 30);
+            this.label3.Location = new System.Drawing.Point(206, 30);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(312, 14);
+            this.label3.Size = new System.Drawing.Size(329, 14);
             this.label3.TabIndex = 56;
             this.label3.Text = "Time Savers / Quality of Life";
             this.label3.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -651,7 +654,7 @@
             this.flpSaveData.Location = new System.Drawing.Point(20, 49);
             this.flpSaveData.Name = "flpSaveData";
             this.flpSaveData.Padding = new System.Windows.Forms.Padding(4, 2, 2, 2);
-            this.flpSaveData.Size = new System.Drawing.Size(179, 73);
+            this.flpSaveData.Size = new System.Drawing.Size(170, 73);
             this.flpSaveData.TabIndex = 67;
             // 
             // flpTimeSavers
@@ -661,15 +664,54 @@
             this.flpTimeSavers.Controls.Add(this.cbFixDream);
             this.flpTimeSavers.Controls.Add(this.cbFixMindPrison);
             this.flpTimeSavers.Controls.Add(this.cbFixCoordinates);
-            this.flpTimeSavers.Controls.Add(this.cbFixLevElevators);
+            this.flpTimeSavers.Controls.Add(this.cbUnlockDanRuins);
             this.flpTimeSavers.Controls.Add(this.cbUnlockGalaxyMap);
-            this.flpTimeSavers.Controls.Add(this.cbDoorFix);
+            this.flpTimeSavers.Controls.Add(this.cbUnlockLevElevators);
+            this.flpTimeSavers.Controls.Add(this.cbUnlockManSub);
+            this.flpTimeSavers.Controls.Add(this.cbUnlockStaBastila);
+            this.flpTimeSavers.Controls.Add(this.cbUnlockUnkSummit);
             this.flpTimeSavers.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flpTimeSavers.Location = new System.Drawing.Point(226, 49);
+            this.flpTimeSavers.Location = new System.Drawing.Point(206, 49);
             this.flpTimeSavers.Name = "flpTimeSavers";
             this.flpTimeSavers.Padding = new System.Windows.Forms.Padding(4, 2, 2, 2);
-            this.flpTimeSavers.Size = new System.Drawing.Size(309, 119);
+            this.flpTimeSavers.Size = new System.Drawing.Size(329, 119);
             this.flpTimeSavers.TabIndex = 68;
+            // 
+            // cbUnlockManSub
+            // 
+            this.cbUnlockManSub.AutoSize = true;
+            this.cbUnlockManSub.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.cbUnlockManSub.Location = new System.Drawing.Point(164, 51);
+            this.cbUnlockManSub.Name = "cbUnlockManSub";
+            this.cbUnlockManSub.Size = new System.Drawing.Size(147, 17);
+            this.cbUnlockManSub.TabIndex = 11;
+            this.cbUnlockManSub.Text = "Unlock MAN Door to Sub";
+            this.cbUnlockManSub.UseVisualStyleBackColor = true;
+            this.cbUnlockManSub.CheckedChanged += new System.EventHandler(this.cbUnlockManSub_CheckedChanged);
+            // 
+            // cbUnlockStaBastila
+            // 
+            this.cbUnlockStaBastila.AutoSize = true;
+            this.cbUnlockStaBastila.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.cbUnlockStaBastila.Location = new System.Drawing.Point(164, 74);
+            this.cbUnlockStaBastila.Name = "cbUnlockStaBastila";
+            this.cbUnlockStaBastila.Size = new System.Drawing.Size(156, 17);
+            this.cbUnlockStaBastila.TabIndex = 12;
+            this.cbUnlockStaBastila.Text = "Unlock STA Door to Bastila";
+            this.cbUnlockStaBastila.UseVisualStyleBackColor = true;
+            this.cbUnlockStaBastila.CheckedChanged += new System.EventHandler(this.cbUnlockStaBastila_CheckedChanged);
+            // 
+            // cbUnlockUnkSummit
+            // 
+            this.cbUnlockUnkSummit.AutoSize = true;
+            this.cbUnlockUnkSummit.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(175)))), ((int)(((byte)(255)))));
+            this.cbUnlockUnkSummit.Location = new System.Drawing.Point(164, 97);
+            this.cbUnlockUnkSummit.Name = "cbUnlockUnkSummit";
+            this.cbUnlockUnkSummit.Size = new System.Drawing.Size(143, 17);
+            this.cbUnlockUnkSummit.TabIndex = 13;
+            this.cbUnlockUnkSummit.Text = "Unlock UNK Summit Exit";
+            this.cbUnlockUnkSummit.UseVisualStyleBackColor = true;
+            this.cbUnlockUnkSummit.CheckedChanged += new System.EventHandler(this.cbUnlockUnkSummit_CheckedChanged);
             // 
             // ModuleForm
             // 
@@ -741,8 +783,8 @@
         private System.Windows.Forms.CheckBox cbUnlockGalaxyMap;
         private System.Windows.Forms.CheckBox cbFixCoordinates;
         private System.Windows.Forms.CheckBox cbFixMindPrison;
-        private System.Windows.Forms.CheckBox cbDoorFix;
-        private System.Windows.Forms.CheckBox cbFixLevElevators;
+        private System.Windows.Forms.CheckBox cbUnlockDanRuins;
+        private System.Windows.Forms.CheckBox cbUnlockLevElevators;
         private System.Windows.Forms.CheckBox cbVulkSpiceLZ;
         private System.Windows.Forms.CheckBox cbReachability;
         private System.Windows.Forms.Label lblGoals;
@@ -774,5 +816,8 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.FlowLayoutPanel flpSaveData;
         private System.Windows.Forms.FlowLayoutPanel flpTimeSavers;
+        private System.Windows.Forms.CheckBox cbUnlockManSub;
+        private System.Windows.Forms.CheckBox cbUnlockStaBastila;
+        private System.Windows.Forms.CheckBox cbUnlockUnkSummit;
     }
 }

--- a/kotor Randomizer 2/Forms/ModuleForm.cs
+++ b/kotor Randomizer 2/Forms/ModuleForm.cs
@@ -40,14 +40,17 @@ namespace kotor_Randomizer_2
             cbSaveAllMods.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.SaveAllModules);
             cbSaveMiniGame.Enabled = !cbSaveAllMods.Checked; // If all save checked, disable mg save checkbox.
 
-            cbFixDream.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.FixDream);
-            cbUnlockGalaxyMap.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockGalaxyMap);
-            cbFixCoordinates.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.FixCoordinates);
-            cbFixMindPrison.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.FixMindPrison);
-
-            cbDoorFix.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockVarDoors);
-            cbFixLevElevators.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators);
             cbVulkSpiceLZ.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.VulkarSpiceLZ);
+            cbFixDream.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.FixDream);
+            cbFixMindPrison.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.FixMindPrison);
+            cbFixCoordinates.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.FixCoordinates);
+
+            cbUnlockDanRuins.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockDanRuins);
+            cbUnlockGalaxyMap.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockGalaxyMap);
+            cbUnlockLevElevators.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockLevElev);
+            cbUnlockManSub.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockManSub);
+            cbUnlockStaBastila.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockStaBastila);
+            cbUnlockUnkSummit.Checked = settings.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockUnkSummit);
 
             // Initialize reachability settings
             cbUseRandoRules.Checked = settings.UseRandoRules;
@@ -284,16 +287,34 @@ namespace kotor_Randomizer_2
             Properties.Settings.Default.ModuleExtrasValue ^= ModuleExtras.FixMindPrison;
         }
 
-        private void cbDoorFix_CheckedChanged(object sender, EventArgs e)
+        private void cbUnlockDanRuins_CheckedChanged(object sender, EventArgs e)
         {
             if (!Constructed) { return; }
-            Properties.Settings.Default.ModuleExtrasValue ^= ModuleExtras.UnlockVarDoors;
+            Properties.Settings.Default.ModuleExtrasValue ^= ModuleExtras.UnlockDanRuins;
         }
 
-        private void cbFixLevElevators_CheckedChanged(object sender, EventArgs e)
+        private void cbUnlockLevElevators_CheckedChanged(object sender, EventArgs e)
         {
             if (!Constructed) { return; }
-            Properties.Settings.Default.ModuleExtrasValue ^= ModuleExtras.FixLevElevators;
+            Properties.Settings.Default.ModuleExtrasValue ^= ModuleExtras.UnlockLevElev;
+        }
+
+        private void cbUnlockManSub_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!Constructed) { return; }
+            Properties.Settings.Default.ModuleExtrasValue ^= ModuleExtras.UnlockManSub;
+        }
+
+        private void cbUnlockStaBastila_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!Constructed) { return; }
+            Properties.Settings.Default.ModuleExtrasValue ^= ModuleExtras.UnlockStaBastila;
+        }
+
+        private void cbUnlockUnkSummit_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!Constructed) { return; }
+            Properties.Settings.Default.ModuleExtrasValue ^= ModuleExtras.UnlockUnkSummit;
         }
 
         private void cbVulkSpiceLZ_CheckedChanged(object sender, EventArgs e)
@@ -389,8 +410,8 @@ namespace kotor_Randomizer_2
                 cbUnlockGalaxyMap.Checked = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockGalaxyMap);
                 cbFixCoordinates.Checked = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixCoordinates);
                 cbFixMindPrison.Checked = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixMindPrison);
-                cbDoorFix.Checked = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockVarDoors);
-                cbFixLevElevators.Checked = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators);
+                cbUnlockDanRuins.Checked = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockDanRuins);
+                cbUnlockLevElevators.Checked = Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockLevElev);
 
                 // Load new reachability settings.
                 cbUseRandoRules.Checked = Properties.Settings.Default.UseRandoRules;

--- a/kotor Randomizer 2/Forms/ModuleForm.cs
+++ b/kotor Randomizer 2/Forms/ModuleForm.cs
@@ -20,8 +20,8 @@ namespace kotor_Randomizer_2
         public ModuleForm()
         {
             InitializeComponent();
-            SetBorder(pnlSaveData, Color.FromArgb(0, 175, 255), 1, BorderStyle.None);
-            SetBorder(pnlTimeSavers, Color.FromArgb(0, 175, 255), 1, BorderStyle.None);
+            SetBorder(flpSaveData, Color.FromArgb(0, 175, 255), 1, BorderStyle.None);
+            SetBorder(flpTimeSavers, Color.FromArgb(0, 175, 255), 1, BorderStyle.None);
             SetBorder(RandomizedListBox, Color.FromArgb(0, 175, 255), 1, BorderStyle.None);
             SetBorder(OmittedListBox, Color.FromArgb(0, 175, 255), 1, BorderStyle.None);
             SetBorder(lblWIP, Color.FromArgb(211, 216, 8), 1, BorderStyle.None);

--- a/kotor Randomizer 2/Globals.cs
+++ b/kotor Randomizer 2/Globals.cs
@@ -48,27 +48,33 @@ namespace kotor_Randomizer_2
     public enum ModuleExtras
     {
         /// <summary> (Default Behavior) Delete milestone save data. </summary>
-        Default         = 0x000, // 0b00 00000000
+        Default          = 0x0000, // 0b00000 00000000
         /// <summary> Do not delete milestone save data. </summary>
-        NoSaveDelete    = 0x001, // 0b00 00000001
+        NoSaveDelete     = 0x0001, // 0b00000 00000001
         /// <summary> Include minigame data in the save file. </summary>
-        SaveMiniGames   = 0x002, // 0b00 00000010
+        SaveMiniGames    = 0x0002, // 0b00000 00000010
         /// <summary> Include all module data in the save file. </summary>
-        SaveAllModules  = 0x004, // 0b00 00000100
+        SaveAllModules   = 0x0004, // 0b00000 00000100
         /// <summary> Fix dream cutscenes. </summary>
-        FixDream        = 0x008, // 0b00 00001000
+        FixDream         = 0x0008, // 0b00000 00001000
         /// <summary> Unlock all destinations on the galaxy map. </summary>
-        UnlockGalaxyMap = 0x010, // 0b00 00010000
+        UnlockGalaxyMap  = 0x0010, // 0b00000 00010000
         /// <summary> Fix warp spawn coordinates in certain modules. </summary>
-        FixCoordinates  = 0x020, // 0b00 00100000
+        FixCoordinates   = 0x0020, // 0b00000 00100000
         /// <summary> Fix Rakatan mind prison to prevent soft-locks. </summary>
-        FixMindPrison   = 0x040, // 0b00 01000000
+        FixMindPrison    = 0x0040, // 0b00000 01000000
         /// <summary> Unlock ancient doors to Dantooine ruins, and on the Lehon Temple roof. </summary>
-        UnlockVarDoors  = 0x080, // 0b00 10000000
-        /// <summary> Allows Leviathan elevators to go to any of the other decks without prerequisites </summary>
-        FixLevElevators = 0x100, // 0b01 00000000
-        /// <summary> Adds a Load Zone leading the the Vulkar Spice in the rear of the Vulkar base main floor, next to the pool </summary>
-        VulkarSpiceLZ   = 0x200, // 0b10 00000000
+        UnlockDanRuins   = 0x0080, // 0b00000 10000000
+        /// <summary> Allows Leviathan elevators to go to any of the other decks without prerequisites. </summary>
+        UnlockLevElev    = 0x0100, // 0b00001 00000000
+        /// <summary> Adds a Load Zone leading the the Vulkar Spice in the rear of the Vulkar base main floor, next to the pool. </summary>
+        VulkarSpiceLZ    = 0x0200, // 0b00010 00000000
+        /// <summary> Unlock the door to the submersible in Manaan's republic embassy. </summary>
+        UnlockManSub     = 0x0400, // 0b00100 00000000
+        /// <summary> Keep the door to Bastila on the Command Center (Deck 3) of the Star Forge unlocked, even after fighting her. </summary>
+        UnlockStaBastila = 0x0800, // 0b01000 00000000
+        /// <summary> Unlock the door that exits from the Temple Summit on the Unknown World. </summary>
+        UnlockUnkSummit  = 0x1000, // 0b10000 00000000
     }
 
     [Flags]

--- a/kotor Randomizer 2/KRP.cs
+++ b/kotor Randomizer 2/KRP.cs
@@ -74,8 +74,8 @@ namespace kotor_Randomizer_2
                         if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.UnlockGalaxyMap; }
                         if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.FixCoordinates; }
                         if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.FixMindPrison; }
-                        if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.UnlockVarDoors; }
-                        if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.FixLevElevators; }
+                        if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.UnlockDanRuins; }
+                        if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.UnlockLevElev; }
                         if (br.ReadBoolean()) { Properties.Settings.Default.ModuleExtrasValue |= ModuleExtras.VulkarSpiceLZ; }
 
                         // Load reachability settings
@@ -338,8 +338,8 @@ namespace kotor_Randomizer_2
                     bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockGalaxyMap));  // Unlocked Galaxy Map
                     bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixCoordinates));   // Fixed Module Coordinates
                     bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixMindPrison));    // Fixed Rakatan Riddles
-                    bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockVarDoors));   // Unlock Problem Doors
-                    bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators));  // Fixed Leviathan Elevators
+                    bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockDanRuins));   // Unlock Problem Doors
+                    bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockLevElev));  // Fixed Leviathan Elevators
                     bw.Write(Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.VulkarSpiceLZ));    // Add Vulkar Spice Loading Zone
 
                     bw.Write(Properties.Settings.Default.UseRandoRules);

--- a/kotor Randomizer 2/Randomization/ModuleRando.cs
+++ b/kotor Randomizer 2/Randomization/ModuleRando.cs
@@ -1,36 +1,43 @@
-﻿using System;
-using System.IO;
-using System.Collections.Generic;
-using System.Linq;
-using System.Data;
+﻿using ClosedXML.Excel;
 using KotOR_IO;
-using ClosedXML.Excel;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System;
 
 namespace kotor_Randomizer_2
 {
     public static class ModuleRando
     {
-        private const string AREA_MYSTERY_BOX = "ebo_m46ab";
-        private const string AREA_EBON_HAWK = "ebo_m12aa";
-        private const string AREA_DANTOOINE_COURTYARD = "danm14aa";
-        private const string AREA_TEMPLE_ROOF = "unk_m44ac";
-        private const string AREA_LEVI_PRISON = "lev_m40aa";
-        private const string AREA_LEVI_COMMAND = "lev_m40ab";
-        private const string AREA_LEVI_HANGAR = "lev_m40ac";
-        private const string AREA_VULKAR_BASE = "tar_m10aa";
-        private const string LABEL_MIND_PRISON = "g_brakatan003";
-        private const string LABEL_MYSTERY_BOX = "pebn_mystery";
-        private const string LABEL_DANTOOINE_DOOR = "man14aa_door04";
-        private const string LABEL_LEHON_DOOR = "unk44_tpllckdoor";
-        private const string LABEL_LEVI_ELEVATOR_A = "plev_elev_dlg";
-        private const string LABEL_LEVI_ELEVATOR_B = "plev_elev_dlg";
-        private const string LABEL_LEVI_ELEVATOR_C = "lev40_accntl_dlg";
-        private const string LABEL_VULK_GIT = "m10aa";
-        private const string TwoDA_MODULE_SAVE = "modulesave.2da";
+        #region Fields
+
+        private const string AREA_DAN_COURTYARD = "danm14aa";
+        private const string AREA_EBO_BOX = "ebo_m46ab";
+        private const string AREA_EBO_HAWK = "ebo_m12aa";
+        private const string AREA_LEV_COMMAND = "lev_m40ab";
+        private const string AREA_LEV_HANGAR = "lev_m40ac";
+        private const string AREA_LEV_PRISON = "lev_m40aa";
+        private const string AREA_TAR_VULK_BASE = "tar_m10aa";
+        private const string AREA_UNK_SUMMIT = "unk_m44ac";
         private const string FIXED_DREAM_OVERRIDE = "k_ren_visionland.ncs";
+        private const string LABEL_DANT_DOOR = "man14aa_door04";
+        private const string LABEL_EBO_BOX = "pebn_mystery";
+        private const string LABEL_EBO_PRISON = "g_brakatan003";
+        private const string LABEL_LEV_ELEVATOR_A = "plev_elev_dlg";
+        private const string LABEL_LEV_ELEVATOR_B = "plev_elev_dlg";
+        private const string LABEL_LEV_ELEVATOR_C = "lev40_accntl_dlg";
+        private const string LABEL_TAR_VULK_GIT = "m10aa";
+        private const string LABEL_UNK_DOOR = "unk44_tpllckdoor";
+
+        private const int MAX_ITERATIONS = 10000;   // A large number to give enough chances to find a valid shuffle.
+
+        private const string TwoDA_MODULE_SAVE = "modulesave.2da";
         private const string UNLOCK_MAP_OVERRIDE = "k_pebn_galaxy.ncs";
 
-        private const int MAX_ITERATIONS = 10000; // Just a random large number to give enough chances to find a valid shuffle.
+        #endregion Fields
+
+        #region Properties
 
         /// <summary>
         /// A lookup table used to know how the modules are randomized.
@@ -43,475 +50,9 @@ namespace kotor_Randomizer_2
         /// </summary>
         private static ModuleDigraph Digraph { get; set; } = new ModuleDigraph(Path.Combine(Environment.CurrentDirectory, "Xml", "KotorModules.xml"));
 
-        /// <summary>
-        /// Populates and shuffles the the modules flagged to be randomized. Returns true if override files should be added.
-        /// </summary>
-        public static void Module_rando(KPaths paths)
-        {
-            // Reset digraph reachability settings.
-            Digraph.ResetSettings();
-            LookupTable.Clear();
+        #endregion Properties
 
-            // Split the Bound modules into their respective lists.
-            List<string> ExcludedModules = Globals.BoundModules.Where(x => x.Omitted).Select(x => x.Code).ToList();
-            List<string> IncludedModules = Globals.BoundModules.Where(x => !x.Omitted).Select(x => x.Code).ToList();
-            bool reachable = false;
-            int iterations = 0;
-
-            // Only shuffle if there is more than 1 module in the shuffle.
-            if (IncludedModules.Count > 1)
-            {
-                if (Properties.Settings.Default.UseRandoRules ||
-                    Properties.Settings.Default.VerifyReachability)
-                {
-                    System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
-                    sw.Start();
-
-                    while (!reachable && iterations < MAX_ITERATIONS)
-                    {
-                        iterations++;
-
-                        Console.WriteLine($"Iteration {iterations}:");
-
-                        // Shuffle the list of included modules.
-                        List<string> ShuffledModules = IncludedModules.ToList();
-                        Randomize.FisherYatesShuffle(ShuffledModules);
-                        LookupTable.Clear();
-
-                        for (int i = 0; i < IncludedModules.Count; i++)
-                        {
-                            LookupTable.Add(IncludedModules[i], ShuffledModules[i]);
-                        }
-
-                        foreach (string name in ExcludedModules)
-                        {
-                            LookupTable.Add(name, name);
-                        }
-
-                        Digraph.SetRandomizationLookup(LookupTable);
-
-                        if (Properties.Settings.Default.UseRandoRules)
-                        {
-                            // Skip to the next iteration if the rules are violated.
-                            if (AreRulesViolated()) continue;
-                        }
-
-                        if (Properties.Settings.Default.VerifyReachability)
-                        {
-                            Digraph.CheckReachability();
-                            reachable = Digraph.IsGoalReachable();
-                        }
-                        else
-                        {
-                            reachable = true;
-                        }
-                    }
-
-                    if (Properties.Settings.Default.VerifyReachability)
-                    {
-                        if (reachable)
-                        {
-                            var message = $"Reachable solution found after {iterations} shuffles. Time elapsed: {sw.Elapsed}";
-                            Console.WriteLine(message);
-                        }
-                        else
-                        {
-                            // Throw an exception if not reachable.
-                            var message = $"No reachable solution found over {iterations} shuffles. Time elapsed: {sw.Elapsed}";
-                            Console.WriteLine(message);
-                            throw new TimeoutException(message);
-                        }
-                    }
-
-                    //digraph.WriteReachableToConsole();
-                    Console.WriteLine();
-                }
-                else
-                {
-                    // Shuffle the list of included modules.
-                    List<string> ShuffledModules = IncludedModules.ToList();
-                    Randomize.FisherYatesShuffle(ShuffledModules);
-                    LookupTable.Clear();
-
-                    for (int i = 0; i < IncludedModules.Count; i++)
-                    {
-                        LookupTable.Add(IncludedModules[i], ShuffledModules[i]);
-                    }
-
-                    foreach (string name in ExcludedModules)
-                    {
-                        LookupTable.Add(name, name);
-                    }
-                }
-            }
-            else
-            {
-                // Create lookup table for later features.
-                LookupTable.Clear();
-
-                for (int i = 0; i < IncludedModules.Count; i++)
-                {
-                    LookupTable.Add(IncludedModules[i], IncludedModules[i]);
-                }
-
-                foreach (string name in ExcludedModules)
-                {
-                    LookupTable.Add(name, name);
-                }
-            }
-
-            // Copy shuffled modules into the base directory.
-            foreach (var name in LookupTable)
-            {
-                File.Copy($"{paths.modules_backup}{name.Key}.rim",   $"{paths.modules}{name.Value}.rim",   true);
-                File.Copy($"{paths.modules_backup}{name.Key}_s.rim", $"{paths.modules}{name.Value}_s.rim", true);
-                File.Copy($"{paths.lips_backup}{name.Key}_loc.mod",  $"{paths.lips}{name.Value}_loc.mod",  true);
-            }
-
-            // Copy lips extras into the base directory.
-            foreach (string name in Globals.lipXtras)
-            {
-                File.Copy($"{paths.lips_backup}{name}", $"{paths.lips}{name}", true);
-            }
-
-            // Write additional override files.
-            string moduleSavePath = Path.Combine(paths.Override, TwoDA_MODULE_SAVE);
-            ModuleExtras saveFileExtras = Properties.Settings.Default.ModuleExtrasValue & (ModuleExtras.SaveAllModules | ModuleExtras.SaveMiniGames | ModuleExtras.NoSaveDelete);
-
-            //if (0 == (saveFileExtras ^ (ModuleExtras.Default)))
-            //{
-            //    // 0b000 - Milestone Delete (Default)
-            //    // Do nothing.
-            //}
-
-            if (0 == (saveFileExtras ^ (ModuleExtras.NoSaveDelete)))
-            {
-                // 0b001 - No Milestone Delete
-                File.WriteAllBytes(moduleSavePath, Properties.Resources.NODELETE_modulesave);
-            }
-
-            if (0 == (saveFileExtras ^ (ModuleExtras.SaveMiniGames)))
-            {
-                // 0b010 - Include Minigames | Milestone Delete
-                File.WriteAllBytes(moduleSavePath, Properties.Resources.MGINCLUDED_modulesave);
-            }
-
-            if (0 == (saveFileExtras ^ (ModuleExtras.NoSaveDelete | ModuleExtras.SaveMiniGames)))
-            {
-                // 0b011 - Include Minigames | No Milestone Delete
-                File.WriteAllBytes(moduleSavePath, Properties.Resources.NODELETE_MGINCLUDED_modulesave);
-            }
-
-            if (0 == (saveFileExtras ^ (ModuleExtras.SaveAllModules)) ||
-                0 == (saveFileExtras ^ (ModuleExtras.SaveMiniGames | ModuleExtras.SaveAllModules)))
-            {
-                // Treat both the same.
-                // 0b100 - Include All Modules | Milestone Delete
-                // 0b110 - Include All Modules | Include Minigames | Milestone Delete
-                File.WriteAllBytes(moduleSavePath, Properties.Resources.ALLINCLUDED_modulesave);
-            }
-
-            if (0 == (saveFileExtras ^ (ModuleExtras.NoSaveDelete | ModuleExtras.SaveAllModules)) ||
-                0 == (saveFileExtras ^ (ModuleExtras.NoSaveDelete | ModuleExtras.SaveMiniGames | ModuleExtras.SaveAllModules)))
-            {
-                // Treat both the same.
-                // 0b101 - Include All Modules | No Milestone Delete
-                // 0b111 - Include All Modules | Include Minigames | No Milestone Delete
-                File.WriteAllBytes(moduleSavePath, Properties.Resources.NODELETE_ALLINCLUDED_modulesave);
-            }
-
-            if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixDream))
-            {
-                File.WriteAllBytes(Path.Combine(paths.Override, FIXED_DREAM_OVERRIDE), Properties.Resources.k_ren_visionland);
-            }
-
-            if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockGalaxyMap))
-            {
-                File.WriteAllBytes(Path.Combine(paths.Override, UNLOCK_MAP_OVERRIDE), Properties.Resources.k_pebn_galaxy);
-            }
-
-            // Fix warp coordinates.
-            if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixCoordinates))
-            {
-                // Create a lookup for modules needing coordinate fix with their newly shuffled FileInfos.
-                var shuffleFileLookup = new Dictionary<string, FileInfo>();
-                foreach (var key in Globals.FIXED_COORDINATES.Keys)
-                {
-                    shuffleFileLookup.Add(key, paths.FilesInModules.FirstOrDefault(fi => fi.Name.Contains(LookupTable[key])));
-                }
-
-                foreach (var kvp in shuffleFileLookup)
-                {
-                    // Set up objects.
-                    RIM r = new RIM(kvp.Value.FullName);
-                    RIM.rFile rf = r.File_Table.Where(x => x.TypeID == (int)ResourceType.IFO).FirstOrDefault();
-
-                    GFF g = new GFF(rf.File_Data);
-
-                    // Update coordinate data.
-                    (g.Top_Level.Fields.Where(x => x.Label == Properties.Resources.ModuleEntryX).FirstOrDefault() as GFF.FLOAT).Value = Globals.FIXED_COORDINATES[kvp.Key].Item1;
-                    (g.Top_Level.Fields.Where(x => x.Label == Properties.Resources.ModuleEntryY).FirstOrDefault() as GFF.FLOAT).Value = Globals.FIXED_COORDINATES[kvp.Key].Item2;
-                    (g.Top_Level.Fields.Where(x => x.Label == Properties.Resources.ModuleEntryZ).FirstOrDefault() as GFF.FLOAT).Value = Globals.FIXED_COORDINATES[kvp.Key].Item3;
-
-                    // Write updated data to RIM file.
-                    rf.File_Data = g.ToRawData();
-                    r.WriteToFile(kvp.Value.FullName);
-                }
-            }
-
-            // Fixed Rakata riddle Man in Mind Prison.
-            if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixMindPrison))
-            {
-                // Allowing Mystery Box to be accessed multiple times...
-                // Find the files associated with AREA_EBON_HAWK.
-                var hawk_files = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_EBON_HAWK]));
-                foreach (FileInfo fi in hawk_files)
-                {
-                    // Skip any files that don't end in "s.rim".
-                    if (fi.Name[fi.Name.Length - 5] != 's') { continue; }
-
-                    // Check the RIM's File_Table for any rFiles labeled with LABEL_MYSTERY_BOX.
-                    RIM r = new RIM(fi.FullName);
-                    if (r.File_Table.Where(x => x.Label == LABEL_MYSTERY_BOX).Any())
-                    {
-                        foreach (RIM.rFile rf in r.File_Table)
-                        {
-                            // For the rFile with LABEL_MIND_PRISON, update the file data with the fix.
-                            if (rf.Label == LABEL_MYSTERY_BOX)
-                            {
-                                rf.File_Data = Properties.Resources.pebn_mystery;
-                                continue;
-                            }
-                        }
-
-                        // Write updated RIM data to file.
-                        r.WriteToFile(fi.FullName);
-                    }
-                }
-
-                // Allowing Riddles to be done more than once...
-                // Find the files associated with AREA_MYSTERY_BOX.
-                var files = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_MYSTERY_BOX]));
-                foreach (FileInfo fi in files)
-                {
-                    // Skip any files that don't end in "s.rim".
-                    if (fi.Name[fi.Name.Length - 5] != 's') { continue; }
-
-                    // Check the RIM's File_Table for any rFiles labeled with LABEL_MIND_PRISON.
-                    RIM r = new RIM(fi.FullName);
-                    if (r.File_Table.Where(x => x.Label == LABEL_MIND_PRISON).Any())
-                    {
-                        foreach (RIM.rFile rf in r.File_Table)
-                        {
-                            // For the rFile with LABEL_MIND_PRISON, update the file data with the fix.
-                            if (rf.Label == LABEL_MIND_PRISON)
-                            {
-                                rf.File_Data = Properties.Resources.g_brakatan003;
-                                continue;
-                            }
-                        }
-
-                        // Write updated RIM data to file.
-                        r.WriteToFile(fi.FullName);
-                    }
-                }
-            }
-
-            // Unlock doors to dantooine ruins and on Lehon Temple Roof
-            if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockVarDoors))
-            {
-                // Dantooine Ruins
-                var dan_files = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_DANTOOINE_COURTYARD]));
-                foreach (FileInfo fi in dan_files)
-                {
-                    // Skip any files that don't end in "s.rim".
-                    if (fi.Name[fi.Name.Length - 5] != 's') { continue; }
-
-                    RIM r_dan = new RIM(fi.FullName); // Open what replaced danm14aa_s.rim
-                    GFF g_dan = new GFF(r_dan.File_Table.Where(x => x.Label == LABEL_DANTOOINE_DOOR).FirstOrDefault().File_Data); // Grab the door out of there
-
-                    // Set the "Locked" field to 0 (false)
-                    (g_dan.Top_Level.Fields.Where(x => x.Label == "Locked").FirstOrDefault() as GFF.BYTE).Value = 0;
-
-                    r_dan.File_Table.Where(x => x.Label == LABEL_DANTOOINE_DOOR).FirstOrDefault().File_Data = g_dan.ToRawData();
-
-                    r_dan.WriteToFile(fi.FullName);
-                }
-
-                // Lehon Temple Roof
-                var unk_files = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_TEMPLE_ROOF]));
-                foreach (FileInfo fi in unk_files)
-                {
-                    // Skip any files that don't end in "s.rim".
-                    if (fi.Name[fi.Name.Length - 5] != 's') { continue; }
-
-                    RIM r_unk = new RIM(fi.FullName); // Open what replaced unk_m44aa_s.rim
-                    GFF g_unk = new GFF(r_unk.File_Table.Where(x => x.Label == LABEL_LEHON_DOOR).FirstOrDefault().File_Data); // Grab the door out of there
-
-                    // Set the "Locked" field to 0 (false)
-                    (g_unk.Top_Level.Fields.Where(x => x.Label == "Locked").FirstOrDefault() as GFF.BYTE).Value = 0;
-
-                    r_unk.File_Table.Where(x => x.Label == LABEL_LEHON_DOOR).FirstOrDefault().File_Data = g_unk.ToRawData();
-
-                    r_unk.WriteToFile(fi.FullName);
-                }
-            }
-
-            // Leviathan Elevators
-            if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators))
-            {
-                var lev_files_a = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_LEVI_PRISON]));
-                var lev_files_b = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_LEVI_COMMAND]));
-                var lev_files_c = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_LEVI_HANGAR]));
-
-                // Prison Block Fix
-                foreach (FileInfo fi in lev_files_a)
-                {
-                    // Skip any files that don't end in "s.rim".
-                    if (fi.Name[fi.Name.Length - 5] != 's') { continue; }
-
-                    RIM r_lev = new RIM(fi.FullName);
-                    GFF g_lev = new GFF(r_lev.File_Table.Where(x => x.Label == LABEL_LEVI_ELEVATOR_A).FirstOrDefault().File_Data);
-
-                    // Change Entry connecting for bridge option Index to 3, which will transition to the command deck
-                    (((g_lev.Top_Level.Fields.Where(x => x.Label == "ReplyList").FirstOrDefault() as GFF.LIST).Structs.Where(x => x.Struct_Type == 3).FirstOrDefault().Fields.Where(x => x.Label == "EntriesList").FirstOrDefault() as GFF.LIST).Structs.Where(x => x.Struct_Type == 0).FirstOrDefault().Fields.Where(x => x.Label == "Index").FirstOrDefault() as GFF.DWORD).Value = 3;
-
-                    // Sets the active reference for the hangar option to nothing, meaning there is no requirement to transition to the hangar
-                    (((g_lev.Top_Level.Fields.Where(x => x.Label == "ReplyList").FirstOrDefault() as GFF.LIST).Structs.Where(x => x.Struct_Type == 1).FirstOrDefault().Fields.Where(x => x.Label == "EntriesList").FirstOrDefault() as GFF.LIST).Structs.Where(x => x.Struct_Type == 0).FirstOrDefault().Fields.Where(x => x.Label == "Active").FirstOrDefault() as GFF.ResRef).Reference = "";
-
-                    r_lev.File_Table.Where(x => x.Label == LABEL_LEVI_ELEVATOR_A).FirstOrDefault().File_Data = g_lev.ToRawData();
-
-                    r_lev.WriteToFile(fi.FullName);
-                }
-
-                // Command Deck Fix
-                foreach (FileInfo fi in lev_files_b)
-                {
-                    // Skip any files that don't end in "s.rim".
-                    if (fi.Name[fi.Name.Length - 5] != 's') { continue; }
-
-                    RIM r_lev = new RIM(fi.FullName);
-                    GFF g_lev = new GFF(r_lev.File_Table.Where(x => x.Label == LABEL_LEVI_ELEVATOR_B).FirstOrDefault().File_Data);
-
-                    // Sets the active reference for the hangar option to nothing, meaning there is no requirement to transition to the hangar
-                    (((g_lev.Top_Level.Fields.Where(x => x.Label == "ReplyList").FirstOrDefault() as GFF.LIST).Structs.Where(x => x.Struct_Type == 1).FirstOrDefault().Fields.Where(x => x.Label == "EntriesList").FirstOrDefault() as GFF.LIST).Structs.Where(x => x.Struct_Type == 1).FirstOrDefault().Fields.Where(x => x.Label == "Active").FirstOrDefault() as GFF.ResRef).Reference = "";
-
-                    r_lev.File_Table.Where(x => x.Label == LABEL_LEVI_ELEVATOR_B).FirstOrDefault().File_Data = g_lev.ToRawData();
-
-                    r_lev.WriteToFile(fi.FullName);
-                }
-
-                // Hangar Fix
-                foreach (FileInfo fi in lev_files_c)
-                {
-                    // Skip any files that don't end in "s.rim".
-                    if (fi.Name[fi.Name.Length - 5] != 's') { continue; }
-
-                    RIM r_lev = new RIM(fi.FullName);
-
-                    // While I possess the ability to edit this file programmatically, due to the complexity I have opted to just load the modded file into resources.
-                    r_lev.File_Table.Where(x => x.Label == LABEL_LEVI_ELEVATOR_C).FirstOrDefault().File_Data = Properties.Resources.lev40_accntl_dlg;
-
-                    // Adding module transition scripts to RIM...
-                    // Prison Block
-                    RIM.rFile to40aa = new RIM.rFile
-                    {
-                        TypeID = (int)ResourceType.NCS,
-                        Label = "k_plev_goto40aa",
-                        File_Data = Properties.Resources.k_plev_goto40aa
-                    };
-                    // Command Deck
-                    RIM.rFile to40ab = new RIM.rFile
-                    {
-                        TypeID = (int)ResourceType.NCS,
-                        Label = "k_plev_goto40ab",
-                        File_Data = Properties.Resources.k_plev_goto40ab
-                    };
-                    // Adding scripts
-                    r_lev.File_Table.Add(to40aa);
-                    r_lev.File_Table.Add(to40ab);
-
-                    r_lev.WriteToFile(fi.FullName);
-
-                }
-            }
-
-            // Vulkar Spice Lab Transition
-            if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.VulkarSpiceLZ))
-            {
-                var vulk_files = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_VULKAR_BASE]));
-                foreach (FileInfo fi in vulk_files)
-                {
-                    // Skip any files that end in "s.rim".
-                    if (fi.Name[fi.Name.Length - 5] == 's') { continue; }
-
-                    RIM r_vul = new RIM(fi.FullName);
-                    r_vul.File_Table.Where(x => x.Label == LABEL_VULK_GIT && x.TypeID == (int)ResourceType.GIT).FirstOrDefault().File_Data = Properties.Resources.m10aa;
-
-                    r_vul.WriteToFile(fi.FullName);
-                }
-            }
-        }
-
-        internal static void Reset()
-        {
-            // Reset digraph reachability settings.
-            Digraph.ResetSettings();
-            // Prepare lists for new randomization.
-            LookupTable.Clear();
-        }
-
-        /// <summary>
-        /// Check to see if the rules are violated.
-        /// If a module's list of bad randomizations contains what replaces it now, the rule is violated.
-        /// </summary>
-        /// <returns></returns>
-        private static bool AreRulesViolated()
-        {
-            // Rule key cannot replace any of the listed values.
-            // LookupTable[Original] = Randomized;
-            //    Pseudocode:
-            // Original = RuleKey;
-            // Randomized = LookupTable[Original];
-            // If RuleList.Contains(Randomized),
-            //    Rule is violated.
-
-            // Check rule 1
-            foreach (var ruleKVP in Globals.RULE1)
-            {
-                var lookup = LookupTable[ruleKVP.Key];
-                if (ruleKVP.Value.Contains(lookup))
-                {
-                    Console.WriteLine($" - Rule 1 violated: {ruleKVP.Key} replaces {lookup}");
-                    return true;
-                }
-            }
-
-            // Check rule 2
-            foreach (var ruleKVP in Globals.RULE2)
-            {
-                var lookup = LookupTable[ruleKVP.Key];
-                if (ruleKVP.Value.Contains(lookup))
-                {
-                    Console.WriteLine($" - Rule 2 violated: {ruleKVP.Key} replaces {lookup}");
-                    return true;
-                }
-            }
-
-            // Check rule 3
-            foreach (var ruleKVP in Globals.RULE3)
-            {
-                var lookup = LookupTable[ruleKVP.Key];
-                if (ruleKVP.Value.Contains(lookup))
-                {
-                    Console.WriteLine($" - Rule 3 violated: {ruleKVP.Key} replaces {lookup}");
-                    return true;
-                }
-            }
-
-            //Console.WriteLine("No rules violated.");
-            return false;
-        }
+        #region Methods
 
         /// <summary>
         /// Creates a CSV file containing a list of the changes made during randomization.
@@ -565,6 +106,10 @@ namespace kotor_Randomizer_2
             }
         }
 
+        /// <summary>
+        /// Creates a worksheet in the given XLWorkbook containing the list of changes made
+        /// during randomization.
+        /// </summary>
         public static void CreateSpoilerLog(XLWorkbook workbook)
         {
             if (LookupTable.Count == 0) { return; }
@@ -663,7 +208,7 @@ namespace kotor_Randomizer_2
 
                 // Handle variable length omitted modules list.
                 if (iMax > i) i = iMax; // Return to bottom of settings list.
-                else          i++;      // Skip a row.
+                else i++;      // Skip a row.
             }
 
             // Module Shuffle
@@ -712,7 +257,7 @@ namespace kotor_Randomizer_2
                 {
                     // Set color of "Has Changed" column. Booleans are automatically centered.
                     if (changed) ws.Cell(i, 1).Style.Font.FontColor = XLColor.Green;
-                    else         ws.Cell(i, 1).Style.Font.FontColor = XLColor.Red;
+                    else ws.Cell(i, 1).Style.Font.FontColor = XLColor.Red;
                 }
                 i++;
             }
@@ -726,13 +271,513 @@ namespace kotor_Randomizer_2
         }
 
         /// <summary>
+        /// Populates and shuffles the the modules flagged to be randomized. Returns true if override files should be added.
+        /// </summary>
+        /// <param name="paths">KPaths object for this game.</param>
+        public static void Module_rando(KPaths paths)
+        {
+            // Reset digraph reachability settings.
+            Digraph.ResetSettings();
+            LookupTable.Clear();
+
+            // Split the Bound modules into their respective lists.
+            bool reachable = false;
+            int iterations = 0;
+
+            // Only shuffle if there is more than 1 module in the shuffle.
+            if (Globals.BoundModules.Count(x => !x.Omitted) > 1)
+            {
+                if (Properties.Settings.Default.UseRandoRules ||
+                    Properties.Settings.Default.VerifyReachability)
+                {
+                    System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
+                    sw.Start();
+
+                    while (!reachable && iterations < MAX_ITERATIONS)
+                    {
+                        iterations++;
+
+                        Console.WriteLine($"Iteration {iterations}:");
+
+                        CreateLookupTableShuffle();
+
+                        Digraph.SetRandomizationLookup(LookupTable);
+
+                        if (Properties.Settings.Default.UseRandoRules)
+                        {
+                            // Skip to the next iteration if the rules are violated.
+                            if (AreRulesViolated()) continue;
+                        }
+
+                        if (Properties.Settings.Default.VerifyReachability)
+                        {
+                            Digraph.CheckReachability();
+                            reachable = Digraph.IsGoalReachable();
+                        }
+                        else
+                        {
+                            reachable = true;
+                        }
+                    }
+
+                    if (Properties.Settings.Default.VerifyReachability)
+                    {
+                        if (reachable)
+                        {
+                            var message = $"Reachable solution found after {iterations} shuffles. Time elapsed: {sw.Elapsed}";
+                            Console.WriteLine(message);
+                        }
+                        else
+                        {
+                            // Throw an exception if not reachable.
+                            var message = $"No reachable solution found over {iterations} shuffles. Time elapsed: {sw.Elapsed}";
+                            Console.WriteLine(message);
+                            throw new TimeoutException(message);
+                        }
+                    }
+
+                    //digraph.WriteReachableToConsole();
+                    Console.WriteLine();
+                }
+                else
+                {
+                    CreateLookupTableShuffle();
+                }
+            }
+            else
+            {
+                CreateLookupTableNoShuffle();
+            }
+
+            WriteFilesToModulesDirectory(paths);
+
+            // Write additional override files.
+            WriteOverrideFiles(paths);
+
+            // Fix warp coordinates.
+            if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixCoordinates))
+            {
+                FixWarpCoordinates(paths);
+            }
+
+            // Fixed Rakata riddle Man in Mind Prison.
+            if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixMindPrison))
+            {
+                FixMindPrison(paths);
+            }
+
+            // Unlock doors to dantooine ruins and on Lehon Temple Roof
+            if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockVarDoors))
+            {
+                UnlockDoorInFile(paths, AREA_DAN_COURTYARD, LABEL_DANT_DOOR);   // Dantooine Ruins
+                UnlockDoorInFile(paths, AREA_UNK_SUMMIT, LABEL_UNK_DOOR);       // Lehon Temple Roof
+            }
+
+            // Leviathan Elevators
+            if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixLevElevators))
+            {
+                FixLeviathanElevators(paths);
+            }
+
+            // Vulkar Spice Lab Transition
+            if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.VulkarSpiceLZ))
+            {
+                var vulk_files = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_TAR_VULK_BASE]));
+                foreach (FileInfo fi in vulk_files)
+                {
+                    // Skip any files that end in "s.rim".
+                    if (fi.Name[fi.Name.Length - 5] == 's') { continue; }
+
+                    RIM r_vul = new RIM(fi.FullName);
+                    r_vul.File_Table.FirstOrDefault(x => x.Label == LABEL_TAR_VULK_GIT && x.TypeID == (int)ResourceType.GIT).File_Data = Properties.Resources.m10aa;
+
+                    r_vul.WriteToFile(fi.FullName);
+                }
+            }
+        }
+
+        /// <summary>
         /// Returns the common name of the given module code. Returns null if the code isn't found.
         /// </summary>
         /// <param name="code"></param>
         /// <returns></returns>
-        public static string GetModuleCommonName(string code)
+        internal static string GetModuleCommonName(string code)
         {
             return Digraph.Modules.FirstOrDefault(m => m.WarpCode == code)?.CommonName;
         }
+
+        /// <summary>
+        /// Resets any fields to prepare for a new shuffle.
+        /// </summary>
+        internal static void Reset()
+        {
+            // Reset digraph reachability settings.
+            Digraph.ResetSettings();
+            // Prepare lists for new randomization.
+            LookupTable.Clear();
+        }
+
+        /// <summary>
+        /// Check to see if the rules are violated.
+        /// If a module's list of bad randomizations contains what replaces it now, the rule is violated.
+        /// </summary>
+        /// <returns></returns>
+        private static bool AreRulesViolated()
+        {
+            // Rule key cannot replace any of the listed values.
+            // LookupTable[Original] = Randomized;
+            //    Pseudocode:
+            // Original = RuleKey;
+            // Randomized = LookupTable[Original];
+            // If RuleList.Contains(Randomized),
+            //    Rule is violated.
+
+            // Check rule 1
+            foreach (var ruleKVP in Globals.RULE1)
+            {
+                var lookup = LookupTable[ruleKVP.Key];
+                if (ruleKVP.Value.Contains(lookup))
+                {
+                    Console.WriteLine($" - Rule 1 violated: {ruleKVP.Key} replaces {lookup}");
+                    return true;
+                }
+            }
+
+            // Check rule 2
+            foreach (var ruleKVP in Globals.RULE2)
+            {
+                var lookup = LookupTable[ruleKVP.Key];
+                if (ruleKVP.Value.Contains(lookup))
+                {
+                    Console.WriteLine($" - Rule 2 violated: {ruleKVP.Key} replaces {lookup}");
+                    return true;
+                }
+            }
+
+            // Check rule 3
+            foreach (var ruleKVP in Globals.RULE3)
+            {
+                var lookup = LookupTable[ruleKVP.Key];
+                if (ruleKVP.Value.Contains(lookup))
+                {
+                    Console.WriteLine($" - Rule 3 violated: {ruleKVP.Key} replaces {lookup}");
+                    return true;
+                }
+            }
+
+            //Console.WriteLine("No rules violated.");
+            return false;
+        }
+
+        /// <summary>
+        /// LookupTable is created from the global BoundModules without shuffling.
+        /// </summary>
+        private static void CreateLookupTableNoShuffle()
+        {
+            // Create lookup table for later features.
+            LookupTable.Clear();
+
+            foreach (var item in Globals.BoundModules)
+            {
+                LookupTable.Add(item.Code, item.Code);
+            }
+        }
+
+        /// <summary>
+        /// LookupTable is created from the global BoundModules after shuffling included modules.
+        /// </summary>
+        private static void CreateLookupTableShuffle()
+        {
+            List<string> excluded = Globals.BoundModules.Where(x => x.Omitted).Select(x => x.Code).ToList();
+            List<string> included = Globals.BoundModules.Where(x => !x.Omitted).Select(x => x.Code).ToList();
+
+            // Shuffle the list of included modules.
+            List<string> shuffle = new List<string>(included);
+            Randomize.FisherYatesShuffle(shuffle);
+            LookupTable.Clear();
+
+            for (int i = 0; i < included.Count; i++)
+            {
+                LookupTable.Add(included[i], shuffle[i]);
+            }
+
+            // Include the unmodified list of excluded modules.
+            foreach (string name in excluded)
+            {
+                LookupTable.Add(name, name);
+            }
+        }
+
+        /// <summary>
+        /// Unlock Leviathan Hangar option in the other two elevator access, and enables the use of the Hangar elevator.
+        /// </summary>
+        /// <param name="paths">KPaths object for this game.</param>
+        private static void FixLeviathanElevators(KPaths paths)
+        {
+            var lev_files_a = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_LEV_PRISON]));
+            var lev_files_b = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_LEV_COMMAND]));
+            var lev_files_c = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[AREA_LEV_HANGAR]));
+
+            // Prison Block Fix - Unlock option to visit Hangar.
+            foreach (FileInfo fi in lev_files_a)
+            {
+                // Skip any files that don't end in "s.rim".
+                if (fi.Name[fi.Name.Length - 5] != 's') { continue; }
+
+                RIM r_lev = new RIM(fi.FullName);
+                GFF g_lev = new GFF(r_lev.File_Table.FirstOrDefault(x => x.Label == LABEL_LEV_ELEVATOR_A).File_Data);
+
+                // Change Entry connecting for bridge option Index to 3, which will transition to the command deck
+                (((g_lev.Top_Level.Fields.FirstOrDefault(x => x.Label == "ReplyList")
+                    as GFF.LIST).Structs.FirstOrDefault(x => x.Struct_Type == 3).Fields.FirstOrDefault(x => x.Label == "EntriesList")
+                    as GFF.LIST).Structs.FirstOrDefault(x => x.Struct_Type == 0).Fields.FirstOrDefault(x => x.Label == "Index")
+                    as GFF.DWORD).Value = 3;
+
+                // Sets the active reference for the hangar option to nothing, meaning there is no requirement to transition to the hangar
+                (((g_lev.Top_Level.Fields.FirstOrDefault(x => x.Label == "ReplyList")
+                    as GFF.LIST).Structs.FirstOrDefault(x => x.Struct_Type == 1).Fields.FirstOrDefault(x => x.Label == "EntriesList")
+                    as GFF.LIST).Structs.FirstOrDefault(x => x.Struct_Type == 0).Fields.FirstOrDefault(x => x.Label == "Active")
+                    as GFF.ResRef).Reference = "";
+
+                r_lev.File_Table.FirstOrDefault(x => x.Label == LABEL_LEV_ELEVATOR_A).File_Data = g_lev.ToRawData();
+
+                r_lev.WriteToFile(fi.FullName);
+            }
+
+            // Command Deck Fix - Unlock option to visit Hangar.
+            foreach (FileInfo fi in lev_files_b)
+            {
+                // Skip any files that don't end in "s.rim".
+                if (fi.Name[fi.Name.Length - 5] != 's') { continue; }
+
+                RIM r_lev = new RIM(fi.FullName);
+                GFF g_lev = new GFF(r_lev.File_Table.FirstOrDefault(x => x.Label == LABEL_LEV_ELEVATOR_B).File_Data);
+
+                // Sets the active reference for the hangar option to nothing, meaning there is no requirement to transition to the hangar
+                (((g_lev.Top_Level.Fields.FirstOrDefault(x => x.Label == "ReplyList")
+                    as GFF.LIST).Structs.FirstOrDefault(x => x.Struct_Type == 1).Fields.FirstOrDefault(x => x.Label == "EntriesList")
+                    as GFF.LIST).Structs.FirstOrDefault(x => x.Struct_Type == 1).Fields.FirstOrDefault(x => x.Label == "Active")
+                    as GFF.ResRef).Reference = "";
+
+                r_lev.File_Table.FirstOrDefault(x => x.Label == LABEL_LEV_ELEVATOR_B).File_Data = g_lev.ToRawData();
+
+                r_lev.WriteToFile(fi.FullName);
+            }
+
+            // Hangar Fix - Enable the elevator so it can be used.
+            foreach (FileInfo fi in lev_files_c)
+            {
+                // Skip any files that don't end in "s.rim".
+                if (fi.Name[fi.Name.Length - 5] != 's') { continue; }
+
+                RIM r_lev = new RIM(fi.FullName);
+
+                // While I possess the ability to edit this file programmatically, due to the complexity I have opted to just load the modded file into resources.
+                r_lev.File_Table.FirstOrDefault(x => x.Label == LABEL_LEV_ELEVATOR_C).File_Data = Properties.Resources.lev40_accntl_dlg;
+
+                // Adding module transition scripts to RIM...
+                // Prison Block
+                r_lev.File_Table.Add(new RIM.rFile
+                {
+                    TypeID = (int)ResourceType.NCS,
+                    Label = "k_plev_goto40aa",
+                    File_Data = Properties.Resources.k_plev_goto40aa
+                });
+                // Command Deck
+                r_lev.File_Table.Add(new RIM.rFile
+                {
+                    TypeID = (int)ResourceType.NCS,
+                    Label = "k_plev_goto40ab",
+                    File_Data = Properties.Resources.k_plev_goto40ab
+                });
+
+                r_lev.WriteToFile(fi.FullName);
+            }
+        }
+
+        /// <summary>
+        /// Allow the Mystery Box and Mind Prison to be used more than once.
+        /// </summary>
+        /// <param name="paths">KPaths object for this game.</param>
+        private static void FixMindPrison(KPaths paths)
+        {
+            // Allowing the Mystery Box to be accessed multiple times.
+            ReplaceSRimFileData(paths, AREA_EBO_HAWK, LABEL_EBO_BOX, Properties.Resources.pebn_mystery);
+
+            // Allowing Riddles to be done more than once.
+            ReplaceSRimFileData(paths, AREA_EBO_BOX, LABEL_EBO_PRISON, Properties.Resources.g_brakatan003);
+        }
+
+        /// <summary>
+        /// Update warp coordinates that are in bad locations by default.
+        /// </summary>
+        /// <param name="paths">KPaths object for this game.</param>
+        private static void FixWarpCoordinates(KPaths paths)
+        {
+            // Create a lookup for modules needing coordinate fix with their newly shuffled FileInfos.
+            var shuffleFileLookup = new Dictionary<string, FileInfo>();
+            foreach (var key in Globals.FIXED_COORDINATES.Keys)
+            {
+                shuffleFileLookup.Add(key, paths.FilesInModules.FirstOrDefault(fi => fi.Name.Contains(LookupTable[key])));
+            }
+
+            foreach (var kvp in shuffleFileLookup)
+            {
+                // Set up objects.
+                RIM r = new RIM(kvp.Value.FullName);
+                RIM.rFile rf = r.File_Table.FirstOrDefault(x => x.TypeID == (int)ResourceType.IFO);
+
+                GFF g = new GFF(rf.File_Data);
+
+                // Update coordinate data.
+                (g.Top_Level.Fields.FirstOrDefault(x => x.Label == Properties.Resources.ModuleEntryX) as GFF.FLOAT).Value = Globals.FIXED_COORDINATES[kvp.Key].Item1;
+                (g.Top_Level.Fields.FirstOrDefault(x => x.Label == Properties.Resources.ModuleEntryY) as GFF.FLOAT).Value = Globals.FIXED_COORDINATES[kvp.Key].Item2;
+                (g.Top_Level.Fields.FirstOrDefault(x => x.Label == Properties.Resources.ModuleEntryZ) as GFF.FLOAT).Value = Globals.FIXED_COORDINATES[kvp.Key].Item3;
+
+                // Write updated data to RIM file.
+                rf.File_Data = g.ToRawData();
+                r.WriteToFile(kvp.Value.FullName);
+            }
+        }
+
+        /// <summary>
+        /// Replace file data within an SRim file.
+        /// </summary>
+        /// <param name="paths">KPaths object for this game.</param>
+        /// <param name="area">Name of the SRim file to modify.</param>
+        /// <param name="label">Label of the rFile to update.</param>
+        /// <param name="rawData">File data to store in the rFile.</param>
+        private static void ReplaceSRimFileData(KPaths paths, string area, string label, byte[] rawData)
+        {
+            // Find the files associated with this area.
+            var area_files = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[area]));
+            foreach (FileInfo file in area_files)
+            {
+                // Skip any files that don't end in "s.rim".
+                if (file.Name[file.Name.Length - 5] != 's') { continue; }
+
+                // Check the RIM's File_Table for any rFiles with the given label.
+                RIM rim = new RIM(file.FullName);
+                var rFiles = rim.File_Table.Where(x => x.Label == label);
+                foreach (RIM.rFile rFile in rFiles)
+                {
+                    rFile.File_Data = rawData;
+                }
+
+                rim.WriteToFile(file.FullName);
+            }
+        }
+
+        /// <summary>
+        /// Unlock a specific door within an SRim file.
+        /// </summary>
+        /// <param name="paths">KPaths object for this game.</param>
+        /// <param name="area">Name of the SRim file to modify.</param>
+        /// <param name="label">Label of the door to unlock.</param>
+        private static void UnlockDoorInFile(KPaths paths, string area, string label)
+        {
+            var areaFiles = paths.FilesInModules.Where(fi => fi.Name.Contains(LookupTable[area]));
+            foreach (FileInfo fi in areaFiles)
+            {
+                // Skip any files that don't end in "s.rim".
+                if (fi.Name[fi.Name.Length - 5] != 's') { continue; }
+
+                RIM r = new RIM(fi.FullName);   // Open what replaced this area.
+                RIM.rFile rf = r.File_Table.FirstOrDefault(x => x.Label == label);
+                GFF g = new GFF(rf.File_Data);  // Grab the door out of the file.
+
+                // Set the "Locked" field to 0 (false).
+                (g.Top_Level.Fields.FirstOrDefault(x => x.Label == "Locked") as GFF.BYTE).Value = 0;
+
+                // Write change(s) to file.
+                rf.File_Data = g.ToRawData();
+                r.WriteToFile(fi.FullName);
+            }
+        }
+
+        /// <summary>
+        /// Copy backup module files to the modules directory based on the current shuffle.
+        /// </summary>
+        /// <param name="paths">KPaths object for this game.</param>
+        private static void WriteFilesToModulesDirectory(KPaths paths)
+        {
+            // Copy shuffled modules into the base directory.
+            foreach (var name in LookupTable)
+            {
+                File.Copy($"{paths.modules_backup}{name.Key}.rim", $"{paths.modules}{name.Value}.rim", true);
+                File.Copy($"{paths.modules_backup}{name.Key}_s.rim", $"{paths.modules}{name.Value}_s.rim", true);
+                File.Copy($"{paths.lips_backup}{name.Key}_loc.mod", $"{paths.lips}{name.Value}_loc.mod", true);
+            }
+
+            // Copy lips extras into the base directory.
+            foreach (string name in Globals.lipXtras)
+            {
+                File.Copy($"{paths.lips_backup}{name}", $"{paths.lips}{name}", true);
+            }
+        }
+
+        /// <summary>
+        /// Write special files to the override folder - save data, dream fix, galaxy map unlock, etc.
+        /// </summary>
+        /// <param name="paths">KPaths object for this game.</param>
+        private static void WriteOverrideFiles(KPaths paths)
+        {
+            string moduleSavePath = Path.Combine(paths.Override, TwoDA_MODULE_SAVE);
+            ModuleExtras saveFileExtras = Properties.Settings.Default.ModuleExtrasValue & (ModuleExtras.SaveAllModules | ModuleExtras.SaveMiniGames | ModuleExtras.NoSaveDelete);
+
+            // Save Data File
+            switch ((int)saveFileExtras)
+            {
+                default:
+                    // 0b000 - Milestone Delete (Default)
+                    // Do nothing.
+                    break;
+
+                case (int)(ModuleExtras.NoSaveDelete):
+                    // 0b001 - No Milestone Delete
+                    File.WriteAllBytes(moduleSavePath, Properties.Resources.NODELETE_modulesave);
+                    break;
+
+                case (int)(ModuleExtras.SaveMiniGames):
+                    // 0b010 - Save Minigames | Milestone Delete
+                    File.WriteAllBytes(moduleSavePath, Properties.Resources.MGINCLUDED_modulesave);
+                    break;
+
+                case (int)(ModuleExtras.NoSaveDelete | ModuleExtras.SaveMiniGames):
+                    // 0b011 - Save Minigames | No Milestone Delete
+                    File.WriteAllBytes(moduleSavePath, Properties.Resources.NODELETE_MGINCLUDED_modulesave);
+                    break;
+
+                case (int)(ModuleExtras.SaveAllModules):
+                case (int)(ModuleExtras.SaveMiniGames | ModuleExtras.SaveAllModules):
+                    // Treat both the same.
+                    // 0b100 - Save All Modules | Milestone Delete
+                    // 0b110 - Save All Modules | Save Minigames | Milestone Delete
+                    File.WriteAllBytes(moduleSavePath, Properties.Resources.ALLINCLUDED_modulesave);
+                    break;
+
+                case (int)(ModuleExtras.NoSaveDelete | ModuleExtras.SaveAllModules):
+                case (int)(ModuleExtras.NoSaveDelete | ModuleExtras.SaveMiniGames | ModuleExtras.SaveAllModules):
+                    // Treat both the same.
+                    // 0b101 - Save All Modules | No Milestone Delete
+                    // 0b111 - Save All Modules | Save Minigames | No Milestone Delete
+                    File.WriteAllBytes(moduleSavePath, Properties.Resources.NODELETE_ALLINCLUDED_modulesave);
+                    break;
+            }
+
+            // Fix Dream File
+            if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.FixDream))
+            {
+                File.WriteAllBytes(Path.Combine(paths.Override, FIXED_DREAM_OVERRIDE), Properties.Resources.k_ren_visionland);
+            }
+
+            // Unlock Galaxy Map File
+            if (Properties.Settings.Default.ModuleExtrasValue.HasFlag(ModuleExtras.UnlockGalaxyMap))
+            {
+                File.WriteAllBytes(Path.Combine(paths.Override, UNLOCK_MAP_OVERRIDE), Properties.Resources.k_pebn_galaxy);
+            }
+        }
+
+        #endregion Methods
     }
 }

--- a/kotor Randomizer 2/Xml/KotorModules.xml
+++ b/kotor Randomizer 2/Xml/KotorModules.xml
@@ -9,7 +9,7 @@
   <Module WarpCode="danm14aa" CommonName="Courtyard">
     <LeadsTo WarpCode="danm13"   CommonName="Jedi Enclave" />
     <LeadsTo WarpCode="danm14ab" CommonName="Matale Grounds" />
-    <LeadsTo WarpCode="danm15"   CommonName="Dantooine Ruins" Tags="Locked,DLZ,FixDoors" Unlock="danm13,danm14ac" />
+    <LeadsTo WarpCode="danm15"   CommonName="Dantooine Ruins" Tags="Locked,DLZ,UL_Ruins" Unlock="danm13,danm14ac" />
   </Module>
   <Module WarpCode="danm14ab" CommonName="Matale Grounds">
     <LeadsTo WarpCode="danm14aa" CommonName="Courtyard" />
@@ -433,7 +433,7 @@
     <LeadsTo WarpCode="unk_m44aa" CommonName="Temple Main Floor" />
   </Module>
   <Module WarpCode="unk_m44ac" CommonName="Temple Summit">
-    <LeadsTo WarpCode="unk_m44aa" CommonName="Temple Main Floor" Tags="Locked,FixDoors" Unlock="Jolee" />
+    <LeadsTo WarpCode="unk_m44aa" CommonName="Temple Main Floor" Tags="Locked,UL_Summit" Unlock="Jolee" />
   </Module>
 
   <!--Repeated Cutscenes-->


### PR DESCRIPTION
Fixes #55. The commits in this pull request focus on updates to the Modules form and randomization code.

4336c9c: This commit focused on refactoring and organizing ModuleRando.cs. I probably should have split the two into separate commits to make it clearer.
- Common functionality was pulled into smaller, reusable methods that could reduce code duplication (e.g., the code to unlock doors or to replace rFile data within an s.rim file).
- The class was organized into regions for fields, properties, and methods. The items within these regions were sorted first on access level and then alphabetized.
- Comments were added to each method to further improve code readability.

7071ad0: This commit gives the user the ability to unlock two additional doors and split the previous "Various Doors" option into two. This added a few more checkboxes to ModuleForm.cs. A better way to organize these options is needed in the future.