### PR TITLE
Ensure floor panel puzzle can be completed after model shuffle

### DIFF
--- a/kotor Randomizer 2/Forms/ModelForm.Designer.cs
+++ b/kotor Randomizer 2/Forms/ModelForm.Designer.cs
@@ -28,166 +28,218 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ModelForm));
             this.cbCharRando = new System.Windows.Forms.CheckBox();
             this.cbDoorRando = new System.Windows.Forms.CheckBox();
             this.cbPlaceRando = new System.Windows.Forms.CheckBox();
-            this.pCharRando = new System.Windows.Forms.Panel();
             this.cbBrokenChars = new System.Windows.Forms.CheckBox();
             this.cbLargeChars = new System.Windows.Forms.CheckBox();
-            this.pPlaceRando = new System.Windows.Forms.Panel();
             this.cbBrokenPlace = new System.Windows.Forms.CheckBox();
             this.cbLargePlace = new System.Windows.Forms.CheckBox();
-            this.pDoorRando = new System.Windows.Forms.Panel();
             this.cbBrokenDoor = new System.Windows.Forms.CheckBox();
             this.cbLargeDoor = new System.Windows.Forms.CheckBox();
             this.label1 = new System.Windows.Forms.Label();
-            this.pCharRando.SuspendLayout();
-            this.pPlaceRando.SuspendLayout();
-            this.pDoorRando.SuspendLayout();
+            this.flpCharRando = new System.Windows.Forms.FlowLayoutPanel();
+            this.flpPlaceRando = new System.Windows.Forms.FlowLayoutPanel();
+            this.flpDoorRando = new System.Windows.Forms.FlowLayoutPanel();
+            this.cbFloorPanels = new System.Windows.Forms.CheckBox();
+            this.ModelToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.flpCharRando.SuspendLayout();
+            this.flpPlaceRando.SuspendLayout();
+            this.flpDoorRando.SuspendLayout();
             this.SuspendLayout();
             // 
             // cbCharRando
             // 
-            this.cbCharRando.Location = new System.Drawing.Point(20, 30);
+            this.cbCharRando.AutoSize = true;
+            this.cbCharRando.Location = new System.Drawing.Point(20, 20);
             this.cbCharRando.Name = "cbCharRando";
-            this.cbCharRando.Size = new System.Drawing.Size(110, 20);
+            this.cbCharRando.Size = new System.Drawing.Size(109, 17);
             this.cbCharRando.TabIndex = 0;
             this.cbCharRando.Text = "Character Models";
+            this.ModelToolTip.SetToolTip(this.cbCharRando, "Character models include all of the NPCs and MOBs that\r\nare not spawned by templa" +
+        "te (such as party members,\r\nthe player, and a few odd creatures).");
             this.cbCharRando.UseVisualStyleBackColor = true;
             this.cbCharRando.CheckedChanged += new System.EventHandler(this.cbCharRando_CheckedChanged);
             // 
             // cbDoorRando
             // 
-            this.cbDoorRando.Location = new System.Drawing.Point(20, 130);
+            this.cbDoorRando.AutoSize = true;
+            this.cbDoorRando.Location = new System.Drawing.Point(20, 161);
             this.cbDoorRando.Name = "cbDoorRando";
-            this.cbDoorRando.Size = new System.Drawing.Size(110, 20);
+            this.cbDoorRando.Size = new System.Drawing.Size(86, 17);
             this.cbDoorRando.TabIndex = 1;
             this.cbDoorRando.Text = "Door Models";
+            this.ModelToolTip.SetToolTip(this.cbDoorRando, "Door models include all door objects such as regular doors,\r\nforce-fields, and ev" +
+        "en sith sarcophagi.");
             this.cbDoorRando.UseVisualStyleBackColor = true;
             this.cbDoorRando.CheckedChanged += new System.EventHandler(this.cbDoorRando_CheckedChanged);
             // 
             // cbPlaceRando
             // 
-            this.cbPlaceRando.Location = new System.Drawing.Point(20, 80);
+            this.cbPlaceRando.AutoSize = true;
+            this.cbPlaceRando.Location = new System.Drawing.Point(20, 79);
             this.cbPlaceRando.Name = "cbPlaceRando";
-            this.cbPlaceRando.Size = new System.Drawing.Size(110, 20);
+            this.cbPlaceRando.Size = new System.Drawing.Size(110, 17);
             this.cbPlaceRando.TabIndex = 2;
             this.cbPlaceRando.Text = "Placeable Models";
+            this.ModelToolTip.SetToolTip(this.cbPlaceRando, "Placeable models include all placeable objects such as\r\nfootlockers, computer con" +
+        "soles, or marker-posts.");
             this.cbPlaceRando.UseVisualStyleBackColor = true;
             this.cbPlaceRando.CheckedChanged += new System.EventHandler(this.cbPlaceRando_CheckedChanged);
             // 
-            // pCharRando
-            // 
-            this.pCharRando.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.pCharRando.Controls.Add(this.cbBrokenChars);
-            this.pCharRando.Controls.Add(this.cbLargeChars);
-            this.pCharRando.Enabled = false;
-            this.pCharRando.Location = new System.Drawing.Point(140, 20);
-            this.pCharRando.Name = "pCharRando";
-            this.pCharRando.Size = new System.Drawing.Size(270, 40);
-            this.pCharRando.TabIndex = 3;
-            // 
             // cbBrokenChars
             // 
-            this.cbBrokenChars.Location = new System.Drawing.Point(140, 10);
+            this.cbBrokenChars.AutoSize = true;
+            this.cbBrokenChars.Location = new System.Drawing.Point(3, 26);
             this.cbBrokenChars.Name = "cbBrokenChars";
-            this.cbBrokenChars.Size = new System.Drawing.Size(130, 20);
+            this.cbBrokenChars.Size = new System.Drawing.Size(121, 17);
             this.cbBrokenChars.TabIndex = 1;
             this.cbBrokenChars.Text = "Omit Broken Models";
+            this.ModelToolTip.SetToolTip(this.cbBrokenChars, "Prevents characters from being randomized to entirely\r\ninvisible or testing model" +
+        "s.");
             this.cbBrokenChars.UseVisualStyleBackColor = true;
             this.cbBrokenChars.CheckedChanged += new System.EventHandler(this.cbBrokenChars_CheckedChanged);
             // 
             // cbLargeChars
             // 
-            this.cbLargeChars.Location = new System.Drawing.Point(10, 10);
+            this.cbLargeChars.AutoSize = true;
+            this.cbLargeChars.Location = new System.Drawing.Point(3, 3);
             this.cbLargeChars.Name = "cbLargeChars";
-            this.cbLargeChars.Size = new System.Drawing.Size(120, 20);
+            this.cbLargeChars.Size = new System.Drawing.Size(114, 17);
             this.cbLargeChars.TabIndex = 0;
             this.cbLargeChars.Text = "Omit Large Models";
+            this.ModelToolTip.SetToolTip(this.cbLargeChars, "Prevents characters from being randomized to some of the\r\nhuge models, such as Kr" +
+        "ayt Dragon or Rancor.");
             this.cbLargeChars.UseVisualStyleBackColor = true;
             this.cbLargeChars.CheckedChanged += new System.EventHandler(this.cbLargeChars_CheckedChanged);
             // 
-            // pPlaceRando
-            // 
-            this.pPlaceRando.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.pPlaceRando.Controls.Add(this.cbBrokenPlace);
-            this.pPlaceRando.Controls.Add(this.cbLargePlace);
-            this.pPlaceRando.Enabled = false;
-            this.pPlaceRando.Location = new System.Drawing.Point(140, 70);
-            this.pPlaceRando.Name = "pPlaceRando";
-            this.pPlaceRando.Size = new System.Drawing.Size(270, 40);
-            this.pPlaceRando.TabIndex = 4;
-            // 
             // cbBrokenPlace
             // 
-            this.cbBrokenPlace.Location = new System.Drawing.Point(140, 10);
+            this.cbBrokenPlace.AutoSize = true;
+            this.cbBrokenPlace.Location = new System.Drawing.Point(3, 26);
             this.cbBrokenPlace.Name = "cbBrokenPlace";
-            this.cbBrokenPlace.Size = new System.Drawing.Size(130, 20);
+            this.cbBrokenPlace.Size = new System.Drawing.Size(121, 17);
             this.cbBrokenPlace.TabIndex = 2;
             this.cbBrokenPlace.Text = "Omit Broken Models";
+            this.ModelToolTip.SetToolTip(this.cbBrokenPlace, "Prevents placeables from being randomized to entirely\r\ninvisible or testing model" +
+        "s.");
             this.cbBrokenPlace.UseVisualStyleBackColor = true;
             this.cbBrokenPlace.CheckedChanged += new System.EventHandler(this.cbBrokenPlace_CheckedChanged);
             // 
             // cbLargePlace
             // 
-            this.cbLargePlace.Location = new System.Drawing.Point(10, 10);
+            this.cbLargePlace.AutoSize = true;
+            this.cbLargePlace.Location = new System.Drawing.Point(3, 3);
             this.cbLargePlace.Name = "cbLargePlace";
-            this.cbLargePlace.Size = new System.Drawing.Size(120, 20);
+            this.cbLargePlace.Size = new System.Drawing.Size(114, 17);
             this.cbLargePlace.TabIndex = 1;
             this.cbLargePlace.Text = "Omit Large Models";
+            this.ModelToolTip.SetToolTip(this.cbLargePlace, "Prevents placeables from being randomized to some of the\r\nhuge models, such as th" +
+        "e invisible acid wall or some land-\r\nspeeders.");
             this.cbLargePlace.UseVisualStyleBackColor = true;
             this.cbLargePlace.CheckedChanged += new System.EventHandler(this.cbLargePlace_CheckedChanged);
             // 
-            // pDoorRando
-            // 
-            this.pDoorRando.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.pDoorRando.Controls.Add(this.cbBrokenDoor);
-            this.pDoorRando.Controls.Add(this.cbLargeDoor);
-            this.pDoorRando.Enabled = false;
-            this.pDoorRando.Location = new System.Drawing.Point(140, 120);
-            this.pDoorRando.Name = "pDoorRando";
-            this.pDoorRando.Size = new System.Drawing.Size(270, 40);
-            this.pDoorRando.TabIndex = 5;
-            // 
             // cbBrokenDoor
             // 
-            this.cbBrokenDoor.Location = new System.Drawing.Point(140, 10);
+            this.cbBrokenDoor.AutoSize = true;
+            this.cbBrokenDoor.Location = new System.Drawing.Point(3, 26);
             this.cbBrokenDoor.Name = "cbBrokenDoor";
-            this.cbBrokenDoor.Size = new System.Drawing.Size(130, 20);
+            this.cbBrokenDoor.Size = new System.Drawing.Size(121, 17);
             this.cbBrokenDoor.TabIndex = 3;
             this.cbBrokenDoor.Text = "Omit Broken Models";
+            this.ModelToolTip.SetToolTip(this.cbBrokenDoor, "Prevents doors from being randomized to entirely invisible\r\nor testing models.");
             this.cbBrokenDoor.UseVisualStyleBackColor = true;
             this.cbBrokenDoor.CheckedChanged += new System.EventHandler(this.cbBrokenDoor_CheckedChanged);
             // 
             // cbLargeDoor
             // 
-            this.cbLargeDoor.Location = new System.Drawing.Point(10, 10);
+            this.cbLargeDoor.AutoSize = true;
+            this.cbLargeDoor.Location = new System.Drawing.Point(3, 3);
             this.cbLargeDoor.Name = "cbLargeDoor";
-            this.cbLargeDoor.Size = new System.Drawing.Size(120, 20);
+            this.cbLargeDoor.Size = new System.Drawing.Size(87, 17);
             this.cbLargeDoor.TabIndex = 2;
             this.cbLargeDoor.Text = "Omit Airlocks";
+            this.ModelToolTip.SetToolTip(this.cbLargeDoor, "Prevents the airlocks in Hrakert Station from being changed,\r\nwhich can sometimes" +
+        " cause them not to function.");
             this.cbLargeDoor.UseVisualStyleBackColor = true;
             this.cbLargeDoor.CheckedChanged += new System.EventHandler(this.cbLargeDoor_CheckedChanged);
             // 
             // label1
             // 
-            this.label1.Location = new System.Drawing.Point(20, 170);
+            this.label1.Location = new System.Drawing.Point(280, 20);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(390, 70);
+            this.label1.Size = new System.Drawing.Size(150, 193);
             this.label1.TabIndex = 6;
             this.label1.Text = resources.GetString("label1.Text");
+            // 
+            // flpCharRando
+            // 
+            this.flpCharRando.AutoSize = true;
+            this.flpCharRando.Controls.Add(this.cbLargeChars);
+            this.flpCharRando.Controls.Add(this.cbBrokenChars);
+            this.flpCharRando.Enabled = false;
+            this.flpCharRando.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flpCharRando.Location = new System.Drawing.Point(138, 17);
+            this.flpCharRando.Name = "flpCharRando";
+            this.flpCharRando.Size = new System.Drawing.Size(129, 53);
+            this.flpCharRando.TabIndex = 7;
+            // 
+            // flpPlaceRando
+            // 
+            this.flpPlaceRando.AutoSize = true;
+            this.flpPlaceRando.Controls.Add(this.cbLargePlace);
+            this.flpPlaceRando.Controls.Add(this.cbBrokenPlace);
+            this.flpPlaceRando.Controls.Add(this.cbFloorPanels);
+            this.flpPlaceRando.Enabled = false;
+            this.flpPlaceRando.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flpPlaceRando.Location = new System.Drawing.Point(138, 76);
+            this.flpPlaceRando.Name = "flpPlaceRando";
+            this.flpPlaceRando.Size = new System.Drawing.Size(127, 76);
+            this.flpPlaceRando.TabIndex = 8;
+            // 
+            // flpDoorRando
+            // 
+            this.flpDoorRando.AutoSize = true;
+            this.flpDoorRando.Controls.Add(this.cbLargeDoor);
+            this.flpDoorRando.Controls.Add(this.cbBrokenDoor);
+            this.flpDoorRando.Enabled = false;
+            this.flpDoorRando.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flpDoorRando.Location = new System.Drawing.Point(138, 158);
+            this.flpDoorRando.Name = "flpDoorRando";
+            this.flpDoorRando.Size = new System.Drawing.Size(130, 55);
+            this.flpDoorRando.TabIndex = 9;
+            // 
+            // cbFloorPanels
+            // 
+            this.cbFloorPanels.AutoSize = true;
+            this.cbFloorPanels.Location = new System.Drawing.Point(3, 49);
+            this.cbFloorPanels.Name = "cbFloorPanels";
+            this.cbFloorPanels.Size = new System.Drawing.Size(110, 17);
+            this.cbFloorPanels.TabIndex = 3;
+            this.cbFloorPanels.Text = "Easy Floor Panels";
+            this.ModelToolTip.SetToolTip(this.cbFloorPanels, "Ensures the floor panels in the Temple Catacombs are not\r\nrandomized to objects t" +
+        "hat have collision too large for the\r\npuzzle to be solved.");
+            this.cbFloorPanels.UseVisualStyleBackColor = true;
+            this.cbFloorPanels.CheckedChanged += new System.EventHandler(this.cbFloorSwitches_CheckedChanged);
+            // 
+            // ModelToolTip
+            // 
+            this.ModelToolTip.AutoPopDelay = 10000;
+            this.ModelToolTip.InitialDelay = 500;
+            this.ModelToolTip.ReshowDelay = 100;
             // 
             // ModelForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(22)))));
-            this.ClientSize = new System.Drawing.Size(432, 261);
+            this.ClientSize = new System.Drawing.Size(444, 230);
+            this.Controls.Add(this.flpDoorRando);
+            this.Controls.Add(this.flpPlaceRando);
+            this.Controls.Add(this.flpCharRando);
             this.Controls.Add(this.label1);
-            this.Controls.Add(this.pDoorRando);
-            this.Controls.Add(this.pPlaceRando);
-            this.Controls.Add(this.pCharRando);
             this.Controls.Add(this.cbPlaceRando);
             this.Controls.Add(this.cbDoorRando);
             this.Controls.Add(this.cbCharRando);
@@ -199,10 +251,14 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Model";
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.ModelForm_FormClosed);
-            this.pCharRando.ResumeLayout(false);
-            this.pPlaceRando.ResumeLayout(false);
-            this.pDoorRando.ResumeLayout(false);
+            this.flpCharRando.ResumeLayout(false);
+            this.flpCharRando.PerformLayout();
+            this.flpPlaceRando.ResumeLayout(false);
+            this.flpPlaceRando.PerformLayout();
+            this.flpDoorRando.ResumeLayout(false);
+            this.flpDoorRando.PerformLayout();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -211,9 +267,6 @@
         private System.Windows.Forms.CheckBox cbCharRando;
         private System.Windows.Forms.CheckBox cbDoorRando;
         private System.Windows.Forms.CheckBox cbPlaceRando;
-        private System.Windows.Forms.Panel pCharRando;
-        private System.Windows.Forms.Panel pPlaceRando;
-        private System.Windows.Forms.Panel pDoorRando;
         private System.Windows.Forms.CheckBox cbBrokenChars;
         private System.Windows.Forms.CheckBox cbLargeChars;
         private System.Windows.Forms.CheckBox cbBrokenPlace;
@@ -221,5 +274,10 @@
         private System.Windows.Forms.CheckBox cbBrokenDoor;
         private System.Windows.Forms.CheckBox cbLargeDoor;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.FlowLayoutPanel flpCharRando;
+        private System.Windows.Forms.FlowLayoutPanel flpPlaceRando;
+        private System.Windows.Forms.FlowLayoutPanel flpDoorRando;
+        private System.Windows.Forms.CheckBox cbFloorPanels;
+        private System.Windows.Forms.ToolTip ModelToolTip;
     }
 }

--- a/kotor Randomizer 2/Forms/ModelForm.cs
+++ b/kotor Randomizer 2/Forms/ModelForm.cs
@@ -33,6 +33,7 @@ namespace kotor_Randomizer_2
             cbPlaceRando.Checked = (Properties.Settings.Default.RandomizePlaceModels & 1) > 0;
             cbLargePlace.Checked = (Properties.Settings.Default.RandomizePlaceModels & 2) > 0;
             cbBrokenPlace.Checked = (Properties.Settings.Default.RandomizePlaceModels & 4) > 0;
+            cbFloorPanels.Checked = (Properties.Settings.Default.RandomizePlaceModels & 8) > 0;
 
             cbDoorRando.Checked = (Properties.Settings.Default.RandomizeDoorModels & 1) > 0;
             cbLargeDoor.Checked = (Properties.Settings.Default.RandomizeDoorModels & 2) > 0; //Airlock ommision
@@ -46,21 +47,21 @@ namespace kotor_Randomizer_2
         //Main Checkboxes
         private void cbCharRando_CheckedChanged(object sender, EventArgs e)
         {
-            pCharRando.Enabled = cbCharRando.Checked;
+            flpCharRando.Enabled = cbCharRando.Checked;
             if (!checks_set) { return; }
             Properties.Settings.Default.RandomizeCharModels ^= 1;
         }
         
         private void cbPlaceRando_CheckedChanged(object sender, EventArgs e)
         {
-            pPlaceRando.Enabled = cbPlaceRando.Checked;
+            flpPlaceRando.Enabled = cbPlaceRando.Checked;
             if (!checks_set) { return; }
             Properties.Settings.Default.RandomizePlaceModels ^= 1;
         }
 
         private void cbDoorRando_CheckedChanged(object sender, EventArgs e)
         {
-            pDoorRando.Enabled = cbDoorRando.Checked;
+            flpDoorRando.Enabled = cbDoorRando.Checked;
             if (!checks_set) { return; }
             Properties.Settings.Default.RandomizeDoorModels ^= 1;
         }
@@ -88,6 +89,12 @@ namespace kotor_Randomizer_2
         {
             if (!checks_set) { return; }
             Properties.Settings.Default.RandomizePlaceModels ^= 1 << 2;
+        }
+
+        private void cbFloorSwitches_CheckedChanged(object sender, EventArgs e)
+        {
+            if (!checks_set) { return; }
+            Properties.Settings.Default.RandomizePlaceModels ^= 1 << 3;
         }
 
         private void cbLargeDoor_CheckedChanged(object sender, EventArgs e)

--- a/kotor Randomizer 2/Forms/ModelForm.resx
+++ b/kotor Randomizer 2/Forms/ModelForm.resx
@@ -117,9 +117,17 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="ModelToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <data name="label1.Text" xml:space="preserve">
     <value>"Large Models" refers to models that only fit in specific circumstances, and can cause playability issues, such as krayt dragon or rancor.
+
 "Broken Models" refers to those that are either not present, or can cause stability issues.
+
 The "Airlocks" of manaan can sometimes loose functionality when randomzied.</value>
   </data>
+  <metadata name="ModelToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/kotor Randomizer 2/Globals.cs
+++ b/kotor Randomizer 2/Globals.cs
@@ -168,12 +168,17 @@ namespace kotor_Randomizer_2
         /// <summary>
         /// Large Placeable Models
         /// </summary>
-        public static readonly List<int> LARGE_PLACE = new List<int>() { 1, 2, 55, 56, 57, 58, 65, 66, 110, 111, 142, 172, 176, 194, 217, 218, 226 }; // NEED TO RESEARCH
+        public static readonly List<int> LARGE_PLACE = new List<int>() { 1, 2, 55, 56, 57, 58, 65, 66, 110, 111, 142, 172, 176, 194, 195, 217, 218, 226 }; // NEED TO RESEARCH
 
         /// <summary>
         /// Broken Placeable Models
         /// </summary>
-        public static readonly List<int> BROKEN_PLACE = new List<int>() { 0, 8, 9, 47, 54, 62, 78, 84, 90, 94, 97, 115, 158, 167, 159, 219 };
+        public static readonly List<int> BROKEN_PLACE = new List<int>() { 0, 8, 9, 47, 54, 62, 78, 84, 90, 94, 96, 97, 115, 121, 158, 167, 159, 219 };
+
+        /// <summary>
+        /// Valid Floor Panel Placeables
+        /// </summary>
+        public static readonly List<int> PANEL_PLACE = new List<int>() { 14, 15, 29, 30, 31, 36, 45, 48, 49, 53, 68, 69, 79, 108, 109, 114, 130, 131, 141, 143, 145, 148, 152, 154, 157, 193, 227, 228, 229, 230, 231 };
 
         /// <summary>
         /// Extra Files found in the 'lips' directory

--- a/kotor Randomizer 2/Randomization/ModelRando.cs
+++ b/kotor Randomizer 2/Randomization/ModelRando.cs
@@ -19,6 +19,10 @@ namespace kotor_Randomizer_2
         private const string DOOR = "Door";
         private const string PLACEABLE = "Placeable";
 
+        private const string AREA_UNK_CATACOMBS = "unk_m44ab";
+        private const string LABEL_UNK_FLPNL = "flpnl";
+        private const string LABEL_UNK_RESETPANEL = "panelreset";
+
         public const string LBL_LOC_NAME = "LocName";
         public const string LBL_GENERIC_TYPE = "GenericType";
         public const string LBL_APPEARANCE = "Appearance";
@@ -118,7 +122,17 @@ namespace kotor_Randomizer_2
 
                         do
                         {
-                            randAppear = Randomize.Rng.Next(0, MAX_PLAC_INDEX);
+                            if (fi.Name.Contains(AREA_UNK_CATACOMBS) &&
+                                (rf.Label.StartsWith(LABEL_UNK_FLPNL) ||
+                                rf.Label == LABEL_UNK_RESETPANEL))
+                            {
+                                randAppear = Globals.PANEL_PLACE[Randomize.Rng.Next(0, Globals.PANEL_PLACE.Count)];
+                            }
+                            else
+                            {
+                                randAppear = Randomize.Rng.Next(0, MAX_PLAC_INDEX);
+                            }
+
                             isBroken = ((Properties.Settings.Default.RandomizePlaceModels & 4) > 0) && Globals.BROKEN_PLACE.Contains(randAppear); // Always Satisfied if Broken omission disbaled
                             isLarge  = ((Properties.Settings.Default.RandomizePlaceModels & 2) > 0) && Globals.LARGE_PLACE.Contains(randAppear);  // Always satisifed if Large omission disabled
                         }


### PR DESCRIPTION
Fixes #56.

- Added option to limit placeable replacements for the floor panels in Temple Summit.
- Organized ModelForm to add the new option.