### PR TITLE
Implemented animation randomization. (#62)

### DIFF
--- a/WpfUI/MainWindow.xaml
+++ b/WpfUI/MainWindow.xaml
@@ -245,6 +245,14 @@
                     <v:CosmeticView x:Name="CosmeticView"
                                     FontSize="{Binding ElementName=cbFontSize, Path=SelectedValue, Converter={StaticResource StringDoubleConverter}}"
                                     
+                                    AnimationAttack    ="{Binding AnimationAttack,     Mode=TwoWay}"
+                                    AnimationDamage    ="{Binding AnimationDamage,     Mode=TwoWay}"
+                                    AnimationFire      ="{Binding AnimationFire,       Mode=TwoWay}"
+                                    AnimationLoop      ="{Binding AnimationLoop,       Mode=TwoWay}"
+                                    AnimationParry     ="{Binding AnimationParry,      Mode=TwoWay}"
+                                    AnimationPause     ="{Binding AnimationPause,      Mode=TwoWay}"
+                                    AnimationMove      ="{Binding AnimationMove,       Mode=TwoWay}"
+                                    
                                     TexturePack        ="{Binding TextureSelectedPack, Mode=TwoWay}"
                                     TextureCubeMaps    ="{Binding TextureCubeMaps    , Mode=TwoWay}"
                                     TextureCreatures   ="{Binding TextureCreatures   , Mode=TwoWay}"

--- a/WpfUI/Views/AudioView.xaml
+++ b/WpfUI/Views/AudioView.xaml
@@ -97,13 +97,13 @@
                             <Setter Property="SubtypeVisible" Value="Hidden" />
                         </Style>
                     </StackPanel.Resources>
-                    <TextBlock Style="{StaticResource tbHeader3}"
+                    <!--<TextBlock Style="{StaticResource tbHeader3}"
                                Text="Music and Sounds"
                                HorizontalAlignment="Center"
                                FontSize="{Binding ElementName=thisView, Path=FontSize, Converter={StaticResource AddToDoubleConverter}, ConverterParameter=4}"
-                               />
+                               />-->
 
-                    <Grid Margin="5">
+                    <Grid Margin="5,0,5,5">
                         <Grid.Resources>
                             <Style TargetType="Button" BasedOn="{StaticResource K1RandoButtonStyle}">
                                 <Setter Property="Margin" Value="5,0,0,0" />

--- a/WpfUI/Views/CosmeticView.xaml
+++ b/WpfUI/Views/CosmeticView.xaml
@@ -49,13 +49,11 @@
         <Border DockPanel.Dock="Top" BorderThickness="0,0,0,2"
                 BorderBrush="{StaticResource HarshBlueBrush}">
             <StackPanel>
-                <TextBlock Style="{StaticResource tbTitle}"
-                           Text="Cosmetic Randomization"
+                <TextBlock Style="{StaticResource tbTitle}" Text="Cosmetic Randomization"
                            FontSize="{Binding ElementName=thisView, Path=FontSize, Converter={StaticResource AddToDoubleConverter}, ConverterParameter=10}"
                            />
                 <TextBlock Style="{StaticResource tbDescription}">
-                    Randomize in-game cosmetics - character models and textures. Model randomization replaces each type of model with a new one within each module.
-                    Texture randomization shuffles the images stored within the texture pack so that all items, objects, etc. look extremely different.
+                    Randomize in-game cosmetics - animations, models, and textures.
                 </TextBlock>
             </StackPanel>
         </Border>
@@ -71,129 +69,182 @@
                         <Setter Property="Padding" Value="2" />
                     </Style>
                 </StackPanel.Resources>
-                
-                <!-- Model Randomization -->
-                <Border>
-                    <Grid Margin="0,3,2,3">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" MinWidth="130" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-                        <Grid.Resources>
-                            <Style TargetType="Border">
-                                <Setter Property="BorderBrush" Value="{StaticResource HarshBlueBrush}" />
-                                <Setter Property="BorderThickness" Value="1" />
-                                <Setter Property="Margin" Value="2" />
-                                <Setter Property="Padding" Value="2" />
-                            </Style>
-                            <Style TargetType="CheckBox">
-                                <Setter Property="Margin" Value="3,3,2,2" />
-                                <Setter Property="Padding" Value="5,0" />
-                                <Setter Property="Tag" Value="{Binding RelativeSource={RelativeSource AncestorType=local:CosmeticView}}" />
-                            </Style>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="{StaticResource HarshBlueBrush}" />
-                                <Style.Triggers>
-                                    <Trigger Property="IsEnabled" Value="False">
-                                        <Setter Property="Foreground" Value="{StaticResource MediumGrayBrush}" />
-                                    </Trigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Grid.Resources>
 
-                        <!--Title-->
-                        <TextBlock Text="Models"
-                                   Grid.ColumnSpan="2"
-                                   Style="{StaticResource tbHeader3}"
-                                   TextDecorations="Underline"
-                                   FontSize="{Binding ElementName=thisView, Path=FontSize, Converter={StaticResource AddToDoubleConverter}, ConverterParameter=2}"
-                                   Margin="5,3,5,10"
-                                   VerticalAlignment="Center"
-                                   />
+                <!-- Animations and Models -->
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="5" />
+                        <ColumnDefinition Width="Auto" MaxWidth="250" />
+                    </Grid.ColumnDefinitions>
 
-                        <!--Character Rando-->
-                        <CheckBox Grid.Row="1" Margin="3,8,0,0" Name="cbCharacterRando" IsChecked="{Binding ModelCharacterRando, Mode=TwoWay}">
-                            <TextBlock Text="Characters" />
-                        </CheckBox>
-                        <Border Grid.Row="1" Grid.Column="1" IsEnabled="{Binding ElementName=cbCharacterRando, Path=IsChecked}">
-                            <StackPanel>
-                                <CheckBox IsChecked="{Binding ModelCharacterOmitLarge, Mode=TwoWay}"
-                                          ToolTip="{StaticResource ttLargeModels}">
-                                    <TextBlock Text="Omit Large Models" />
-                                </CheckBox>
-                                <CheckBox IsChecked="{Binding ModelCharacterOmitBroken, Mode=TwoWay}"
-                                          ToolTip="{StaticResource ttBrokenModels}">
-                                    <TextBlock Text="Omit Broken Models" />
-                                </CheckBox>
+                    <!-- Animation Randomization -->
+                    <Border Grid.Column="0">
+                        <Grid Margin="0,3,2,3">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="130" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" MinWidth="120" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Grid.Resources>
+                                <Style TargetType="Button" BasedOn="{StaticResource K1RandoButtonStyle}">
+                                    <Setter Property="Margin" Value="5,0" />
+                                    <Setter Property="Padding" Value="8,1" />
+                                </Style>
+                            </Grid.Resources>
+
+                            <!--Title-->
+                            <TextBlock Text="Animations"
+                                       Style="{StaticResource tbHeader3}"
+                                       TextDecorations="Underline"
+                                       FontSize="{Binding ElementName=thisView, Path=FontSize, Converter={StaticResource AddToDoubleConverter}, ConverterParameter=2}"
+                                       Margin="5,0,5,5"
+                                       VerticalAlignment="Center"
+                                       />
+
+                            <!--Toggle Buttons-->
+                            <Button Margin="8,0,0,0" Grid.Row="1" Content="Toggle All" Click="BtnToggleAllAnimation_Click" />
+                            <StackPanel Grid.Column="2" Grid.ColumnSpan="2" Grid.Row="1"
+                                        Orientation="Horizontal" HorizontalAlignment="Right">
+                                <Button Content="Type" Click="BtnTypeAnimation_Click" />
+                                <Button Content="Max"  Click="BtnMaxAnimation_Click" />
                             </StackPanel>
-                        </Border>
 
-                        <!--Placeable Rando-->
-                        <CheckBox Grid.Row="2" Margin="3,8,0,0" Name="cbPlaceableRando" IsChecked="{Binding ModelPlaceableRando, Mode=TwoWay}">
-                            <TextBlock Text="Placeables" />
-                        </CheckBox>
-                        <Border Grid.Row="2" Grid.Column="1" IsEnabled="{Binding ElementName=cbPlaceableRando, Path=IsChecked}">
-                            <StackPanel>
-                                <CheckBox IsChecked="{Binding ModelPlaceableOmitLarge, Mode=TwoWay}"
-                                          ToolTip="{StaticResource ttLargeModels}">
-                                    <TextBlock Text="Omit Large Models" />
-                                </CheckBox>
-                                <CheckBox IsChecked="{Binding ModelPlaceableOmitBroken, Mode=TwoWay}"
-                                          ToolTip="{StaticResource ttBrokenModels}">
-                                    <TextBlock Text="Omit Broken Models" />
-                                </CheckBox>
-                                <CheckBox IsChecked="{Binding ModelPlaceableEasyPanels, Mode=TwoWay}"
-                                          ToolTip="{StaticResource ttFloorPanels}">
-                                    <TextBlock Text="Easy Floor Panels" />
-                                </CheckBox>
+                            <!--Options-->
+                            <StackPanel Margin="3,5,1,5" Grid.Row="2" Grid.ColumnSpan="3">
+                                <StackPanel.Resources>
+                                    <Style TargetType="uc:RandomizationLevelUserControl">
+                                        <Setter Property="Margin" Value="0,1" />
+                                        <Setter Property="SubtypeVisible" Value="Collapsed" />
+                                    </Style>
+                                </StackPanel.Resources>
+                                <uc:RandomizationLevelUserControl x:Name="rlucAnimationAttack" CheckboxLabel="Attack"   SelectedLevel="{Binding ElementName=thisView, Mode=TwoWay, Path=AnimationAttack}" />
+                                <uc:RandomizationLevelUserControl x:Name="rlucAnimationDamage" CheckboxLabel="Damage"   SelectedLevel="{Binding ElementName=thisView, Mode=TwoWay, Path=AnimationDamage}" />
+                                <uc:RandomizationLevelUserControl x:Name="rlucAnimationParry"  CheckboxLabel="Parry"    SelectedLevel="{Binding ElementName=thisView, Mode=TwoWay, Path=AnimationParry}" />
+                                <uc:RandomizationLevelUserControl x:Name="rlucAnimationMove"   CheckboxLabel="Movement" SelectedLevel="{Binding ElementName=thisView, Mode=TwoWay, Path=AnimationMove}" />
+                                <uc:RandomizationLevelUserControl x:Name="rlucAnimationPause"  CheckboxLabel="Pause"    SelectedLevel="{Binding ElementName=thisView, Mode=TwoWay, Path=AnimationPause}" />
+                                <uc:RandomizationLevelUserControl x:Name="rlucAnimationLoop"   CheckboxLabel="Looping"  SelectedLevel="{Binding ElementName=thisView, Mode=TwoWay, Path=AnimationLoop}" />
+                                <uc:RandomizationLevelUserControl x:Name="rlucAnimationForget" CheckboxLabel="Various"  SelectedLevel="{Binding ElementName=thisView, Mode=TwoWay, Path=AnimationFire}" />
                             </StackPanel>
-                        </Border>
+                        </Grid>
+                    </Border>
 
-                        <!--Door Rando-->
-                        <CheckBox Grid.Row="3" Margin="3,8,0,0" Name="cbDoorRando" IsChecked="{Binding ModelDoorRando, Mode=TwoWay}">
-                            <TextBlock Text="Doors" />
-                        </CheckBox>
-                        <Border Grid.Row="3" Grid.Column="1" IsEnabled="{Binding ElementName=cbDoorRando, Path=IsChecked}">
-                            <StackPanel>
-                                <CheckBox IsChecked="{Binding ModelDoorOmitAirlock, Mode=TwoWay}"
-                                          ToolTip="{StaticResource ttAirlocks}">
-                                    <TextBlock Text="Omit Airlocks" />
-                                </CheckBox>
-                                <CheckBox IsChecked="{Binding ModelDoorOmitBroken, Mode=TwoWay}"
-                                          ToolTip="{StaticResource ttBrokenModels}">
-                                    <TextBlock Text="Omit Broken Models" />
-                                </CheckBox>
-                            </StackPanel>
-                        </Border>
+                    <!-- Model Randomization -->
+                    <Border Grid.Column="2">
+                        <Grid Margin="0,3,2,3">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid.Resources>
+                                <Style TargetType="Border">
+                                    <Setter Property="BorderBrush" Value="{StaticResource HarshBlueBrush}" />
+                                    <Setter Property="BorderThickness" Value="1" />
+                                    <Setter Property="Margin" Value="10,5" />
+                                    <Setter Property="Padding" Value="2" />
+                                </Style>
+                                <Style TargetType="CheckBox">
+                                    <Setter Property="Margin" Value="3,3,2,2" />
+                                    <Setter Property="Padding" Value="5,0" />
+                                    <Setter Property="Tag" Value="{Binding RelativeSource={RelativeSource AncestorType=local:CosmeticView}}" />
+                                </Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Foreground" Value="{StaticResource HarshBlueBrush}" />
+                                    <Style.Triggers>
+                                        <Trigger Property="IsEnabled" Value="False">
+                                            <Setter Property="Foreground" Value="{StaticResource MediumGrayBrush}" />
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Grid.Resources>
 
-                        <!--Description-->
-                        <!--<Border Grid.RowSpan="4" Grid.Column="2"
-                                BorderThickness="1,0,0,0">
-                            <StackPanel>
-                                <TextBlock Style="{StaticResource tbDescription}">
-                                    "Large Models" are those that don't fit in most circumstances and thus cause
-                                    playability issues (krayt dragon, rancor, etc).
-                                </TextBlock>
-                                <TextBlock Style="{StaticResource tbDescription}">
-                                    "Broken Models" are those that are either not present or can cause stability issues.
-                                </TextBlock>
-                                <TextBlock Style="{StaticResource tbDescription}">
-                                    "Easy Floor Panels" ensures the puzzle in the Temple Catacombs is solvable.
-                                </TextBlock>
-                                <TextBlock Style="{StaticResource tbDescription}">
-                                    The "Airlocks" of Manaan can sometimes lose functionality when randomized.
-                                </TextBlock>
+                            <!--Title-->
+                            <TextBlock Text="Models"
+                                       Grid.ColumnSpan="2"
+                                       Style="{StaticResource tbHeader3}"
+                                       TextDecorations="Underline"
+                                       FontSize="{Binding ElementName=thisView, Path=FontSize, Converter={StaticResource AddToDoubleConverter}, ConverterParameter=2}"
+                                       Margin="5,0,5,5"
+                                       VerticalAlignment="Center"
+                                       />
+
+                            <!--Character Rando-->
+                            <StackPanel Grid.Row="1">
+                                <CheckBox Grid.Row="1" Name="cbCharacterRando" IsChecked="{Binding ModelCharacterRando, Mode=TwoWay}">
+                                    <TextBlock Text="Characters" />
+                                </CheckBox>
+                                <Border Grid.Row="1" Grid.Column="1" HorizontalAlignment="Center"
+                                        IsEnabled="{Binding ElementName=cbCharacterRando, Path=IsChecked}">
+                                    <StackPanel>
+                                        <CheckBox IsChecked="{Binding ModelCharacterOmitLarge, Mode=TwoWay}"
+                                                  ToolTip="{StaticResource ttLargeModels}">
+                                            <TextBlock Text="Omit Large Models" />
+                                        </CheckBox>
+                                        <CheckBox IsChecked="{Binding ModelCharacterOmitBroken, Mode=TwoWay}"
+                                                  ToolTip="{StaticResource ttBrokenModels}">
+                                            <TextBlock Text="Omit Broken Models" />
+                                        </CheckBox>
+                                    </StackPanel>
+                                </Border>
                             </StackPanel>
-                        </Border>-->
-                    </Grid>
-                </Border>
+
+                            <!--Placeable Rando-->
+                            <StackPanel Grid.Row="2">
+                                <CheckBox Grid.Row="2" Margin="3,0,0,0" Name="cbPlaceableRando" IsChecked="{Binding ModelPlaceableRando, Mode=TwoWay}">
+                                    <TextBlock Text="Placeables" />
+                                </CheckBox>
+                                <Border Grid.Row="2" Grid.Column="1" HorizontalAlignment="Center"
+                                        IsEnabled="{Binding ElementName=cbPlaceableRando, Path=IsChecked}">
+                                    <StackPanel>
+                                        <CheckBox IsChecked="{Binding ModelPlaceableOmitLarge, Mode=TwoWay}"
+                                                  ToolTip="{StaticResource ttLargeModels}">
+                                            <TextBlock Text="Omit Large Models" />
+                                        </CheckBox>
+                                        <CheckBox IsChecked="{Binding ModelPlaceableOmitBroken, Mode=TwoWay}"
+                                                  ToolTip="{StaticResource ttBrokenModels}">
+                                            <TextBlock Text="Omit Broken Models" />
+                                        </CheckBox>
+                                        <CheckBox IsChecked="{Binding ModelPlaceableEasyPanels, Mode=TwoWay}"
+                                                  ToolTip="{StaticResource ttFloorPanels}">
+                                            <TextBlock Text="Easy Floor Panels" />
+                                        </CheckBox>
+                                    </StackPanel>
+                                </Border>
+                            </StackPanel>
+
+                            <!--Door Rando-->
+                            <StackPanel Grid.Row="3">
+                                <CheckBox Grid.Row="3" Margin="3,0,0,0" Name="cbDoorRando" IsChecked="{Binding ModelDoorRando, Mode=TwoWay}">
+                                    <TextBlock Text="Doors" />
+                                </CheckBox>
+                                <Border Grid.Row="3" Grid.Column="1" HorizontalAlignment="Center" Margin="10,5,10,0"
+                                        IsEnabled="{Binding ElementName=cbDoorRando, Path=IsChecked}">
+                                    <StackPanel>
+                                        <CheckBox IsChecked="{Binding ModelDoorOmitAirlock, Mode=TwoWay}"
+                                                  ToolTip="{StaticResource ttAirlocks}">
+                                            <TextBlock Text="Omit Airlocks" />
+                                        </CheckBox>
+                                        <CheckBox IsChecked="{Binding ModelDoorOmitBroken, Mode=TwoWay}"
+                                                  ToolTip="{StaticResource ttBrokenModels}">
+                                            <TextBlock Text="Omit Broken Models" />
+                                        </CheckBox>
+                                    </StackPanel>
+                                </Border>
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+                </Grid>
+
                 
                 <!-- Texture Randomization -->
                 <Border>
@@ -251,12 +302,12 @@
                                        Style="{StaticResource tbHeader3}"
                                        TextDecorations="Underline"
                                        FontSize="{Binding ElementName=thisView, Path=FontSize, Converter={StaticResource AddToDoubleConverter}, ConverterParameter=2}"
-                                       Margin="5,3,5,10"
+                                       Margin="5,0,5,5"
                                        VerticalAlignment="Center"
                                        />
                         </DockPanel>
 
-                        <!--Pack-->
+                        <!-- Pack -->
                         <Border Grid.Column="2" Grid.RowSpan="2"
                                 Margin="1,0,1,5">
                             <StackPanel Margin="2">
@@ -275,7 +326,8 @@
 
                         <!-- Toggle Buttons -->
                         <Button Grid.Row="2" Margin="8,0,0,0" Content="Toggle All" Click="BtnToggleAll_Click" />
-                        <StackPanel Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right">
+                        <StackPanel Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2"
+                                    Orientation="Horizontal" HorizontalAlignment="Right">
                             <Button Content="Type" Click="BtnType_Click" />
                             <Button Content="Max"  Click="BtnMax_Click" />
                         </StackPanel>
@@ -298,15 +350,16 @@
                             <uc:RandomizationLevelUserControl x:Name="rlucOther"        CheckboxLabel="Other"         SelectedLevel="{Binding ElementName=thisView, Mode=TwoWay, Path=TextureOther       }" />
                         </StackPanel>
 
+                        <!-- Notice -->
                         <Border Grid.Row="4" Grid.ColumnSpan="3"
                                 BorderThickness="0,1,0,0"
                                 Margin="3,0,1,0" Padding="0,3,0,0">
                             <TextBlock Style="{StaticResource tbDescription}" TextWrapping="Wrap"
                                        Margin="0,0,0,0" Padding="0,0,0,0">
-                            Notice: The stability of this feature is still questionable. If you receive
-                            any pop-ups or warnings about "invalid bumpmaps" please contact Lane Dibello
-                            with the texture name so he can omit it from the randomization. If you encounter
-                            issues mid-run, change your quality settings to revert to normal.
+                                Notice: The stability of this feature is still questionable. If you receive
+                                any pop-ups or warnings about "invalid bumpmaps" please contact Lane Dibello
+                                with the texture name so he can omit it from the randomization. If you encounter
+                                issues mid-run, change your quality settings to revert to normal.
                             </TextBlock>
                         </Border>
                     </Grid>

--- a/WpfUI/Views/CosmeticView.xaml.cs
+++ b/WpfUI/Views/CosmeticView.xaml.cs
@@ -23,6 +23,7 @@ namespace Randomizer_WPF.Views
     public partial class CosmeticView : UserControl
     {
         #region Members
+        private List<RandomizationLevelUserControl> AnimationControls;
         private List<RandomizationLevelUserControl> TextureControls;
         #endregion
 
@@ -30,6 +31,16 @@ namespace Randomizer_WPF.Views
         public CosmeticView()
         {
             InitializeComponent();
+            AnimationControls = new List<RandomizationLevelUserControl>()
+            {
+                rlucAnimationAttack,
+                rlucAnimationDamage,
+                rlucAnimationForget,
+                rlucAnimationLoop,
+                rlucAnimationParry,
+                rlucAnimationPause,
+                rlucAnimationMove,
+            };
             TextureControls = new List<RandomizationLevelUserControl>()
             {
                 rlucCreatures,
@@ -51,6 +62,14 @@ namespace Randomizer_WPF.Views
         #endregion
 
         #region Dependency Properties
+        public static readonly DependencyProperty AnimationAttackProperty = DependencyProperty.Register("AnimationAttack", typeof(RandomizationLevel), typeof(CosmeticView));
+        public static readonly DependencyProperty AnimationDamageProperty = DependencyProperty.Register("AnimationDamage", typeof(RandomizationLevel), typeof(CosmeticView));
+        public static readonly DependencyProperty AnimationFireProperty   = DependencyProperty.Register("AnimationFire",   typeof(RandomizationLevel), typeof(CosmeticView));
+        public static readonly DependencyProperty AnimationLoopProperty   = DependencyProperty.Register("AnimationLoop",   typeof(RandomizationLevel), typeof(CosmeticView));
+        public static readonly DependencyProperty AnimationParryProperty  = DependencyProperty.Register("AnimationParry",  typeof(RandomizationLevel), typeof(CosmeticView));
+        public static readonly DependencyProperty AnimationPauseProperty  = DependencyProperty.Register("AnimationPause",  typeof(RandomizationLevel), typeof(CosmeticView));
+        public static readonly DependencyProperty AnimationMoveProperty   = DependencyProperty.Register("AnimationMove",   typeof(RandomizationLevel), typeof(CosmeticView));
+
         public static readonly DependencyProperty TexturePackProperty = DependencyProperty.Register("TexturePack", typeof(TexturePack), typeof(CosmeticView), new PropertyMetadata(TexturePack.LowQuality, HandleTexturePackChanged));
 
         public static readonly DependencyProperty TextureCubeMapsProperty     = DependencyProperty.Register("TextureCubeMaps",     typeof(RandomizationLevel), typeof(CosmeticView));
@@ -70,6 +89,49 @@ namespace Randomizer_WPF.Views
         #endregion
 
         #region Properties
+
+        public RandomizationLevel AnimationAttack
+        {
+            get { return (RandomizationLevel)GetValue(AnimationAttackProperty); }
+            set { SetValue(AnimationAttackProperty, value); }
+        }
+
+        public RandomizationLevel AnimationDamage
+        {
+            get { return (RandomizationLevel)GetValue(AnimationDamageProperty); }
+            set { SetValue(AnimationDamageProperty, value); }
+        }
+
+        public RandomizationLevel AnimationFire
+        {
+            get { return (RandomizationLevel)GetValue(AnimationFireProperty); }
+            set { SetValue(AnimationFireProperty, value); }
+        }
+
+        public RandomizationLevel AnimationLoop
+        {
+            get { return (RandomizationLevel)GetValue(AnimationLoopProperty); }
+            set { SetValue(AnimationLoopProperty, value); }
+        }
+
+        public RandomizationLevel AnimationParry
+        {
+            get { return (RandomizationLevel)GetValue(AnimationParryProperty); }
+            set { SetValue(AnimationParryProperty, value); }
+        }
+
+        public RandomizationLevel AnimationPause
+        {
+            get { return (RandomizationLevel)GetValue(AnimationPauseProperty); }
+            set { SetValue(AnimationPauseProperty, value); }
+        }
+
+        public RandomizationLevel AnimationMove
+        {
+            get { return (RandomizationLevel)GetValue(AnimationMoveProperty); }
+            set { SetValue(AnimationMoveProperty, value); }
+        }
+
         public TexturePack TexturePack
         {
             get { return (TexturePack)GetValue(TexturePackProperty); }
@@ -200,6 +262,31 @@ namespace Randomizer_WPF.Views
         private void BtnMax_Click(object sender, RoutedEventArgs e)
         {
             foreach (var item in TextureControls)
+            {
+                item.SelectedLevel = RandomizationLevel.Max;
+            }
+        }
+
+        private void BtnToggleAllAnimation_Click(object sender, RoutedEventArgs e)
+        {
+            bool CheckAllBoxes = AnimationControls.Any(rluc => !rluc.IsChecked);
+            foreach (var item in AnimationControls)
+            {
+                item.IsChecked = CheckAllBoxes;
+            }
+        }
+
+        private void BtnTypeAnimation_Click(object sender, RoutedEventArgs e)
+        {
+            foreach (var item in AnimationControls)
+            {
+                item.SelectedLevel = RandomizationLevel.Type;
+            }
+        }
+
+        private void BtnMaxAnimation_Click(object sender, RoutedEventArgs e)
+        {
+            foreach (var item in AnimationControls)
             {
                 item.SelectedLevel = RandomizationLevel.Max;
             }

--- a/kotor Randomizer 2/Models/Kotor1Randomizer.cs
+++ b/kotor Randomizer 2/Models/Kotor1Randomizer.cs
@@ -34,6 +34,7 @@ namespace kotor_Randomizer_2.Models
         const string XML_AREA           = "Area";
         const string XML_ARMBAND        = "Armband";
         const string XML_ARMOR          = "Armor";
+        const string XML_ATTACK         = "Attack";
         const string XML_AUDIO          = "Audio";
         const string XML_BATTLE         = "Battle";
         const string XML_BELT           = "Belt";
@@ -49,11 +50,13 @@ namespace kotor_Randomizer_2.Models
         const string XML_CUBE_MAP       = "CubeMap";
         const string XML_CUTSCENE       = "Cutscene";
         const string XML_CWEAPON        = "CWeapon";
+        const string XML_DAMAGE         = "Damage";
         const string XML_DLZ            = "DLZ";
         const string XML_DOOR           = "Door";
         const string XML_DROID          = "Droid";
         const string XML_EASY_PANELS    = "EasyPanels";
         const string XML_EFFECT         = "Effect";
+        const string XML_FIRE           = "Fire";
         const string XML_FIRST_NAME_F   = "FirstF";
         const string XML_FIRST_NAME_M   = "FirstM";
         const string XML_FLU            = "FLU";
@@ -70,6 +73,7 @@ namespace kotor_Randomizer_2.Models
         const string XML_LAST_NAME      = "Last";
         const string XML_LIGHTSABER     = "Lightsaber";
         const string XML_LOGIC          = "Logic";
+        const string XML_LOOP           = "Loop";
         const string XML_MALAK          = "Malak";
         const string XML_MAPS           = "StarMaps";
         const string XML_MASK           = "Mask";
@@ -79,6 +83,7 @@ namespace kotor_Randomizer_2.Models
         const string XML_MIXNPCPARTY    = "MixNpcParty";
         const string XML_MODEL          = "Model";
         const string XML_MODULE         = "Module";
+        const string XML_MOVE           = "Move";
         const string XML_NAME           = "Name";
         const string XML_NAMES          = "Names";
         const string XML_NPC            = "Npc";
@@ -88,7 +93,9 @@ namespace kotor_Randomizer_2.Models
         const string XML_OMIT_LARGE     = "OmitLarge";
         const string XML_OTHER          = "Other";
         const string XML_PACK           = "Pack";
+        const string XML_PARRY          = "Parry";
         const string XML_PARTY          = "Party";
+        const string XML_PAUSE          = "Pause";
         const string XML_PAZAAK         = "Pazaak";
         const string XML_PLAC           = "Placeable";
         const string XML_PLACE          = "Placeable";
@@ -115,6 +122,7 @@ namespace kotor_Randomizer_2.Models
         const string XML_VARIOUS        = "Various";
         const string XML_VERSION        = "Version";
         const string XML_VEHICLE        = "Vehicle";
+        const string XML_WALK           = "Walk";
         const string XML_WEAPON         = "Weapon";
         #endregion XML Consts
         #endregion
@@ -223,6 +231,57 @@ namespace kotor_Randomizer_2.Models
         #endregion Constructors
 
         #region Properties
+        #region Animation Properties
+        private RandomizationLevel _animationAttack;
+        public RandomizationLevel AnimationAttack
+        {
+            get => _animationAttack;
+            set => SetField(ref _animationAttack, value);
+        }
+
+        private RandomizationLevel _animationDamage;
+        public RandomizationLevel AnimationDamage
+        {
+            get => _animationDamage;
+            set => SetField(ref _animationDamage, value);
+        }
+
+        private RandomizationLevel _animationFire;
+        public RandomizationLevel AnimationFire
+        {
+            get => _animationFire;
+            set => SetField(ref _animationFire, value);
+        }
+
+        private RandomizationLevel _animationLoop;
+        public RandomizationLevel AnimationLoop
+        {
+            get => _animationLoop;
+            set => SetField(ref _animationLoop, value);
+        }
+
+        private RandomizationLevel _animationParry;
+        public RandomizationLevel AnimationParry
+        {
+            get => _animationParry;
+            set => SetField(ref _animationParry, value);
+        }
+
+        private RandomizationLevel _animationPause;
+        public RandomizationLevel AnimationPause
+        {
+            get => _animationPause;
+            set => SetField(ref _animationPause, value);
+        }
+
+        private RandomizationLevel _animationMove;
+        public RandomizationLevel AnimationMove
+        {
+            get => _animationMove;
+            set => SetField(ref _animationMove, value);
+        }
+        #endregion
+
         #region Audio Properties
         private RandomizationLevel _audioAmbientNoise;
         public RandomizationLevel AudioAmbientNoise
@@ -830,6 +889,17 @@ namespace kotor_Randomizer_2.Models
         #endregion Texture Properties
 
         #region Active Rando Properties
+        public bool DoRandomizeAnimation
+        {
+            get
+            {
+                return
+                    (AnimationAttack | AnimationDamage | AnimationFire | AnimationLoop
+                    | AnimationParry | AnimationPause  | AnimationMove)
+                    != RandomizationLevel.None;
+            }
+        }
+
         public bool DoRandomizeAudio
         {
             get
@@ -913,7 +983,8 @@ namespace kotor_Randomizer_2.Models
         {
             get
             {
-                return Table2DAs.Any(rt => rt.IsRandomized);
+                return Table2DAs.Any(rt => rt.IsRandomized) ||
+                       DoRandomizeAnimation;
             }
         }
         public bool DoRandomizeText
@@ -2147,6 +2218,14 @@ namespace kotor_Randomizer_2.Models
         /// <param name="element">XML element containing the table settings.</param>
         private void ReadTableSettings(XElement element)
         {
+            { if (element.Attribute(XML_ATTACK) is XAttribute attr) AnimationAttack = ParseEnum<RandomizationLevel>(attr.Value); }
+            { if (element.Attribute(XML_DAMAGE) is XAttribute attr) AnimationDamage = ParseEnum<RandomizationLevel>(attr.Value); }
+            { if (element.Attribute(XML_FIRE  ) is XAttribute attr) AnimationFire   = ParseEnum<RandomizationLevel>(attr.Value); }
+            { if (element.Attribute(XML_LOOP  ) is XAttribute attr) AnimationLoop   = ParseEnum<RandomizationLevel>(attr.Value); }
+            { if (element.Attribute(XML_PARRY ) is XAttribute attr) AnimationParry  = ParseEnum<RandomizationLevel>(attr.Value); }
+            { if (element.Attribute(XML_PAUSE ) is XAttribute attr) AnimationPause  = ParseEnum<RandomizationLevel>(attr.Value); }
+            { if (element.Attribute(XML_MOVE   ) is XAttribute attr) AnimationMove   = ParseEnum<RandomizationLevel>(attr.Value); }
+
             foreach (var tbl in element.Descendants(XML_TABLE))
             {
                 var name = tbl.Attribute(XML_NAME).Value;
@@ -2395,6 +2474,15 @@ namespace kotor_Randomizer_2.Models
         private void WriteTableSettings(XmlTextWriter w)
         {
             w.WriteStartElement(XML_TABLES);    // Start Tables
+
+            if (AnimationAttack != RandomizationLevel.None) w.WriteAttributeString(XML_ATTACK, AnimationAttack.ToString());
+            if (AnimationDamage != RandomizationLevel.None) w.WriteAttributeString(XML_DAMAGE, AnimationDamage.ToString());
+            if (AnimationFire   != RandomizationLevel.None) w.WriteAttributeString(XML_FIRE,   AnimationFire.ToString());
+            if (AnimationLoop   != RandomizationLevel.None) w.WriteAttributeString(XML_LOOP,   AnimationLoop.ToString());
+            if (AnimationParry  != RandomizationLevel.None) w.WriteAttributeString(XML_PARRY,  AnimationParry.ToString());
+            if (AnimationPause  != RandomizationLevel.None) w.WriteAttributeString(XML_PAUSE,  AnimationPause.ToString());
+            if (AnimationMove   != RandomizationLevel.None) w.WriteAttributeString(XML_MOVE,   AnimationMove.ToString());
+
             foreach (var table in Table2DAs.Where(rt => rt.IsRandomized))
             {
                 w.WriteStartElement(XML_TABLE);    // Start Table

--- a/kotor Randomizer 2/Randomization/TwodaRandom.cs
+++ b/kotor Randomizer 2/Randomization/TwodaRandom.cs
@@ -18,6 +18,62 @@ namespace kotor_Randomizer_2
 
         public static Dictionary<string, List<string>> Selected2DAs { get; set; }
 
+        /// <summary> List of animations to randomize all together. </summary>
+        private static List<Animation> AniMaxRando { get; } = new List<Animation>();
+
+        /// <summary> List of creature animations to randomize all together. </summary>
+        private static List<Animation> AniMaxRandoCreatures { get; } = new List<Animation>();
+
+        /// <summary> Collection of lists of animations to be randomized by type. </summary>
+        private static List<List<Animation>> AnimationTypeLists { get; } = new List<List<Animation>>();
+
+        /// <summary> Alignment stance animations. </summary>
+        private static readonly List<string> AniAlignment = new List<string>() { "good", "neutral", "evil" };
+
+        /// <summary> Unused animations and animations whose usage is unknown. These seem to include some cutscene specific animations. </summary>
+        private static readonly List<int> AniUnused = new List<int>()
+        {
+            // Appears Unused
+            111, 112, 152, 153, 193, 194, 238, 246, 250, 265,   // c2f1, c2f2, c3f1, c3f2, c4f1, c4f2, g6r2, g7r2, g8r2, fear
+            // Unknown Usage
+            010, 011, 055, 056, 077, 292, 293, 294, 295, 296,   // hturnr, hturnl, drink, cardplay, spasm, turnforward, castout1, castout2, castout3, powerup
+            297, 298, 299, 300, 301, 302, 303, 304, 305, 306,   // powered, powerdown, disabled, attack, parry, dodge, default, damage, default, die
+            307, 308, 309, 310, 311, 312, 313, 314, 315, 316,   // dead, on, off, open, close, close2open, open2close, on2off, off2on, animloop01
+            317, 318, 319, 320, 321, 322, 323, 324, 325, 326,   // animloop02, animloop03, animloop04, animloop05, animloop06, animloop07, animloop08, animloop09, animloop10, pause
+            327, 328, 329, 330, 331, 332, 333, 334, 335, 336,   // default, damage, die, dead, opened1, opened2, closed, opening1, opening2, closing1
+            337, 344, 346, 347, 348, 349, 350, 355, 356, 357,   // closing2, trans, usecomp, default, activate, deactivate, detect, fblock, off, pause2
+            358, 359, 360, 366, 367, 368, 369, 370, 372, 373,   // cpause2, pause3, weld, busted, turnleft, turnright, weld, talkinj, talkinj, equip
+            374, 375, 379, 380, 383, 384, 385,                  // die3, dead3, g0a1, b0a1, kd, kdtlkangry, kdtlksad
+        };
+
+        /// <summary> Creature animations. </summary>
+        private static readonly List<int> AniCreatures = new List<int>()
+        {
+            125, 126, 127, 128, 129, 130, 166, 167, 168, 169,   // m2a1, m2a2, m2g1, m2g2, m2d1, m2d2, m3a1, m3a2, m3g1, m3g2
+            170, 171, 207, 208, 209, 210, 211, 212, 253, 254,   // m3d1, m3d2, m4a1, m4a2, m4g1, m4g2, m4d1, m4d2, cwalk, cwalkinj
+            255, 256, 257, 258, 259, 260, 261, 262, 263, 264,   // crun, cpause1, cpause2, chturnl, chturnr, cvictory, tlknorm, talk, ctaunt, choke
+            266, 267, 268, 269, 271, 272, 273, 274, 275, 276,   // whirlwind, sleep, cspasm, paralyzed, ckdbcklp, ckdbck, cgustandb, cdie, cdead, g0a1
+            277, 278, 279, 280, 281, 282, 283, 284, 285, 286,   // g0a2, creadyr, creadyrtw, cdamages, cdodgeg, m0a1, m0a2, m0p1, m0p2, m0d1
+            287,                                                // m0d2
+        };
+
+        public static RandomizationLevel AnimationAttack { get; set; }
+        public static RandomizationLevel AnimationDamage { get; set; }
+        public static RandomizationLevel AnimationFire { get; set; }
+        public static RandomizationLevel AnimationLoop { get; set; }
+        public static RandomizationLevel AnimationParry { get; set; }
+        public static RandomizationLevel AnimationPause { get; set; }
+        public static RandomizationLevel AnimationMove { get; set; }
+
+        public static bool IsAnimationRandomized
+        {
+            get
+            {
+                RandomizationLevel full = AnimationAttack | AnimationDamage | AnimationFire | AnimationLoop | AnimationParry | AnimationPause | AnimationMove;
+                return full != RandomizationLevel.None;
+            }
+        }
+
         /// <summary>
         /// Creates backups for files modified during this randomization.
         /// </summary>
@@ -30,6 +86,8 @@ namespace kotor_Randomizer_2
 
         public static void Twoda_rando(KPaths paths, Kotor1Randomizer k1rando = null)
         {
+            // Prepare for new randomization.
+            Reset();
             AssignSettings(k1rando);
 
             BIF b = new BIF(Path.Combine(paths.data, "2da.bif"));
@@ -79,8 +137,217 @@ namespace kotor_Randomizer_2
 
                 t.WriteToDirectory(paths.Override); // Write new 2DA data to file.
             }
+
+            if (IsAnimationRandomized)
+            {
+                BIF.VariableResourceEntry VRE = b.VariableResourceTable.FirstOrDefault(x => x.ResRef == "animations");
+                if (VRE != null)
+                {
+                    TwoDA t;
+                    if (filesInOverride.Any(fi => fi.Name == "animations.2da"))
+                    {
+                        // Modify the existing table.
+                        t = new TwoDA(File.ReadAllBytes(filesInOverride.First(fi => fi.Name == "animations.2da").FullName), VRE.ResRef);
+                    }
+                    else
+                    {
+                        // Fetch the table from the 2DA BIF file.
+                        t = new TwoDA(VRE.EntryData, VRE.ResRef);
+                    }
+
+                    if (!LookupTable.ContainsKey(VRE.ResRef))
+                    {
+                        // Add 2DA to the table.
+                        LookupTable.Add(VRE.ResRef, new Dictionary<string, List<Tuple<string, string>>>());
+                    }
+
+                    RandomizeAnimations(t);
+                    t.WriteToDirectory(paths.Override); // Write new 2DA data to file.
+                }
+            }
         }
 
+        /// <summary>
+        /// Perform requested animation randomizations by category.
+        /// </summary>
+        /// <param name="t">Table containing "animations"</param>
+        private static void RandomizeAnimations(TwoDA t)
+        {
+            // Parse animations into a usable structure.
+            List<Animation> animations = ParseAnimations(t);
+            var animationLookup = new List<Tuple<string, string>>();
+
+            // Remove animations that shouldn't be randomized.
+            animations.RemoveAll(a => AniUnused.Contains(a.Id));    // Remove unused or unknown animations.
+            animations = animations.GroupBy(a => a.Name).Select(g => g.First()).ToList();   // Remove duplicates.
+
+            /// Handle animation categories. The order here matters because they are removed from "animations" each time they are handled.
+            /// Creatures are handled before humanoids to keep them separate. Max rando lists are separate as well.
+            // Handle attacks.
+            animations = HandleCategory(animations, AnimationAttack, animations.Where(a => a.Attack == "1" && AniCreatures.Contains(a.Id)).ToList(), true);
+            animations = HandleCategory(animations, AnimationAttack, animations.Where(a => a.Attack == "1").ToList());
+
+            // Handle damage.
+            animations = HandleCategory(animations, AnimationDamage, animations.Where(a => a.Damage == "1" && AniCreatures.Contains(a.Id)).ToList(), true);
+            animations = HandleCategory(animations, AnimationDamage, animations.Where(a => a.Damage == "1").ToList());
+
+            // Handle parry.
+            animations = HandleCategory(animations, AnimationParry, animations.Where(a => a.Parry == "1" && AniCreatures.Contains(a.Id)).ToList(), true);
+            animations = HandleCategory(animations, AnimationParry, animations.Where(a => a.Parry == "1").ToList());
+
+            // Handle pause.
+            animations = HandleCategory(animations, AnimationPause, animations.Where(a => a.Pause == "1" && AniCreatures.Contains(a.Id)).ToList(), true);
+            animations = HandleCategory(animations, AnimationPause, animations.Where(a => a.Pause == "1").ToList());
+
+            // Handle movement.
+            animations = HandleCategory(animations, AnimationMove, animations.Where(a => (a.Run == "1" || a.Walk == "1") && AniCreatures.Contains(a.Id)).ToList(), true);
+            animations = HandleCategory(animations, AnimationMove, animations.Where(a => a.Run == "1" || a.Walk == "1").ToList());
+
+            // Handle looping.
+            animations = HandleCategory(animations, AnimationLoop, animations.Where(a => a.Loop == "1" && AniCreatures.Contains(a.Id)).ToList(), true);
+            animations = HandleCategory(animations, AnimationLoop, animations.Where(a => a.Loop == "1" && AniAlignment.Contains(a.Name)).ToList());
+            animations = HandleCategory(animations, AnimationLoop, animations.Where(a => a.Loop == "1").ToList());
+
+            // Handle fire and forget.
+            animations = HandleCategory(animations, AnimationFire, animations.Where(a => a.Fire == "1" && AniCreatures.Contains(a.Id)).ToList(), true);
+            animations = HandleCategory(animations, AnimationFire, animations.Where(a => a.Fire == "1").ToList());
+
+            // Perform max rando.
+            var oldMax = AniMaxRando.ToList();
+            Randomize.FisherYatesShuffle(AniMaxRando);
+            for (int i = 0; i < oldMax.Count; i++)
+            {
+                animationLookup.Add(new Tuple<string, string>(oldMax[i].Name, AniMaxRando[i].Name));
+                t.Data["name"][oldMax[i].Id] = AniMaxRando[i].Name.ToString();
+            }
+
+            // Perform type rando.
+            foreach (var typeList in AnimationTypeLists)
+            {
+                var randoType = typeList.ToList();
+                Randomize.FisherYatesShuffle(randoType);
+                for (int i = 0; i < typeList.Count; i++)
+                {
+                    animationLookup.Add(new Tuple<string, string>(typeList[i].Name, randoType[i].Name));
+                    t.Data["name"][typeList[i].Id] = randoType[i].Name.ToString();
+                }
+            }
+
+            // Add animation table changes to LookupTable.
+            LookupTable[t.Name].Add("name", animationLookup);
+        }
+
+        /// <summary>
+        /// Parses the "animations" table from the 2DA to create a list of Animation objects.
+        /// </summary>
+        /// <param name="t">Table containing "animations"</param>
+        /// <returns>List of parsed Animation objects</returns>
+        private static List<Animation> ParseAnimations(TwoDA t)
+        {
+            var animations = new List<Animation>();
+            for (int i = 0; i < t.RowCount; i++)
+            {
+                var animation = new Animation();
+                foreach (var column in t.Data)
+                {
+                    switch (column.Key)
+                    {
+                        case "row_index":
+                            animation.Id = int.Parse(column.Value[i]);
+                            break;
+                        case "name":
+                            animation.Name = column.Value[i];
+                            break;
+                        case "stationary":
+                            animation.Stationary = column.Value[i];
+                            break;
+                        case "pause":
+                            animation.Pause = column.Value[i];
+                            break;
+                        case "walking":
+                            animation.Walk = column.Value[i];
+                            break;
+                        case "running":
+                            animation.Run = column.Value[i];
+                            break;
+                        case "looping":
+                            animation.Loop = column.Value[i];
+                            break;
+                        case "fireforget":
+                            animation.Fire = column.Value[i];
+                            break;
+                        case "overlay":
+                            animation.Overlay = column.Value[i];
+                            break;
+                        case "playoutofplace":
+                            animation.PlayOutOfPlace = column.Value[i];
+                            break;
+                        case "dialog":
+                            animation.Dialog = column.Value[i];
+                            break;
+                        case "damage":
+                            animation.Damage = column.Value[i];
+                            break;
+                        case "parry":
+                            animation.Parry = column.Value[i];
+                            break;
+                        case "dodge":
+                            animation.Dodge = column.Value[i];
+                            break;
+                        case "attack":
+                            animation.Attack = column.Value[i];
+                            break;
+                        case "hideequippeditems":
+                            animation.HideEquippedItems = column.Value[i];
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                animations.Add(animation);
+            }
+
+            return animations;
+        }
+
+        /// <summary>
+        /// Sorts animations into type or max randomization based on the RandomizationLevel and if it is a creature animation.
+        /// </summary>
+        /// <param name="fullList">Full list of animations from which to remove the short list.</param>
+        /// <param name="level">Randomization level for this category.</param>
+        /// <param name="shortList">List of animations for this category.</param>
+        /// <param name="isCreature">Is this a set of creature animations?</param>
+        /// <returns>Full list of animations with this category of animations removed.</returns>
+        private static List<Animation> HandleCategory(List<Animation> fullList, RandomizationLevel level, List<Animation> shortList, bool isCreature = false)
+        {
+            switch (level)
+            {
+                default:
+                case RandomizationLevel.None:
+                case RandomizationLevel.Subtype:
+                    break;  // Do nothing.
+                case RandomizationLevel.Type:
+                    AnimationTypeLists.Add(shortList);
+                    break;
+                case RandomizationLevel.Max:
+                    if (isCreature)
+                    {
+                        AniMaxRandoCreatures.AddRange(shortList);
+                    }
+                    else
+                    {
+                        AniMaxRando.AddRange(shortList);
+                    }
+                    break;
+            }
+
+            return fullList.Except(shortList).ToList();
+        }
+
+        /// <summary>
+        /// Grabs table related settings from the Kotor1Randomizer object.
+        /// </summary>
+        /// <param name="k1rando">Randomizer settings object.</param>
         private static void AssignSettings(Kotor1Randomizer k1rando)
         {
             if (k1rando == null)
@@ -94,26 +361,74 @@ namespace kotor_Randomizer_2
                 {
                     Selected2DAs.Add(table.Name, table.Randomized.ToList());
                 }
+
+                AnimationAttack = k1rando.AnimationAttack;
+                AnimationDamage = k1rando.AnimationDamage;
+                AnimationFire = k1rando.AnimationFire;
+                AnimationLoop = k1rando.AnimationLoop;
+                AnimationParry = k1rando.AnimationParry;
+                AnimationPause = k1rando.AnimationPause;
+                AnimationMove = k1rando.AnimationMove;
             }
         }
 
+        /// <summary>
+        /// Prepare lists for a new randomization.
+        /// </summary>
         internal static void Reset()
         {
             // Prepare lists for new randomization.
+            AniMaxRando.Clear();
+            AnimationTypeLists.Clear();
             LookupTable.Clear();
             Selected2DAs = null;
         }
 
+        /// <summary>
+        /// Creates a worksheet containing the spoiler information for this TwoDA randomization.
+        /// </summary>
+        /// <param name="workbook">Workbook to add the new worksheet to.</param>
         internal static void CreateSpoilerLog(XLWorkbook workbook)
         {
+            const string ORIGINAL = "Orig";
+            const string RANDOM = "Rand";
+
             if (LookupTable.Count == 0) { return; }
             var ws = workbook.Worksheets.Add("TwoDA");
             int i = 1;
 
-            // TwoDA Randomization
-            const string ORIGINAL = "Orig";
-            const string RANDOM   = "Rand";
+            // TwoDA Randomization Settings
+            ws.Cell(i, 1).Value = "Animation Type";
+            ws.Cell(i, 2).Value = "Rando Level";
+            ws.Cell(i, 1).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 1).Style.Font.Bold = true;
+            ws.Cell(i, 2).Style.Border.BottomBorder = XLBorderStyleValues.Thin;
+            ws.Cell(i, 2).Style.Font.Bold = true;
+            i++;
 
+            var settings = new List<Tuple<string, string>>()
+            {
+                new Tuple<string, string>("Attack", AnimationAttack.ToString()),
+                new Tuple<string, string>("Damage", AnimationDamage.ToString()),
+                new Tuple<string, string>("Fire",   AnimationFire.ToString()),
+                new Tuple<string, string>("Loop",   AnimationLoop.ToString()),
+                new Tuple<string, string>("Parry",  AnimationParry.ToString()),
+                new Tuple<string, string>("Pause",  AnimationPause.ToString()),
+                new Tuple<string, string>("Move",   AnimationMove.ToString()),
+                new Tuple<string, string>("", ""),  // Skip a row.
+            };
+
+            foreach (var setting in settings)
+            {
+                ws.Cell(i, 1).Value = setting.Item1;
+                ws.Cell(i, 2).Value = setting.Item2;
+                ws.Cell(i, 1).Style.Font.Italic = true;
+                i++;
+            }
+
+            i++;    // Skip a row.
+
+            // TwoDA Randomization
             int iDone = i;
             int j = 1;
             int jMax = 1;
@@ -169,5 +484,35 @@ namespace kotor_Randomizer_2
                 ws.Column(c).AdjustToContents();
             }
         }
+
+        #region Nested Classes
+        /// <summary>
+        /// Parsed entry in the "animations" table.
+        /// </summary>
+        internal struct Animation
+        {
+            public int Id;
+            public string Name;
+            public string Stationary;
+            public string Pause;
+            public string Walk;
+            public string Run;
+            public string Loop;
+            public string Fire;
+            public string Overlay;
+            public string PlayOutOfPlace;
+            public string Dialog;
+            public string Damage;
+            public string Parry;
+            public string Dodge;
+            public string Attack;
+            public string HideEquippedItems;
+
+            public override string ToString()
+            {
+                return $"{Id}: {Name}";
+            }
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
*Summary*
Animation randomization is implemented, and the settings are added to the cosmetics view.

*Implementation*
Randomization is performed similar to other categories, using randomization levels, type and max lists, and some additional filtering to remove troublesome animations. Seven types of animations are used, aligning with several of the columns within the "animations" table: attack, damage, parry, movement, pause, looping, and various (fireforget). Walking and running were combined to create the movement type so there is more variety within that type. The other columns are ignored as they are handled by the others or by the filters.

*Filters*
To ensure the animations shuffled are usable, valid, and don't cause breaking issues within the normal course of play, several filters were implemented. To assist this process, the animation descriptions from Kotor 2's animations table were correlated to the Kotor 1 table.
- First, any animations that were described as "Appears Unused" or had a blank description were filtered.
- Next, any animation that has a duplicate name is removed, leaving only the first entry in the table.
- Finally, when each type of animation is randomized, those that are used for creatures (monsters) are randomized and filtered beforehand.
- Also, alignment stances are filtered beforehand to avoid getting stuck in place. (Other animations also seem to cause this issue. Further testing is required.)

*User Interface*
The animation rando settings were added to the Cosmetics view. Instead of adding a new box and pushing everything further down, I made Animations and Models share the same row, with the Models box on the right side of the page.